### PR TITLE
Ming/mfb 385 data dbt models for expenses

### DIFF
--- a/dbt/models/postgres/marts/mart_screener_expense.sql
+++ b/dbt/models/postgres/marts/mart_screener_expense.sql
@@ -1,10 +1,14 @@
 {{
   config(
     materialized='table',
-    description='Materialized mart for expense'
+    description='Materialized mart for expenses data'
   )
 }}
 
-
-SELECT *
-FROM {{ ref('stg_expenses') }}
+select
+    d.id as screener_id
+    ,d.submission_date::date as submission_date
+    ,d.white_label_id
+    ,se.*
+from {{ ref('stg_expenses') }} se
+inner join {{ ref('int_complete_screener_data') }} d ON se.screen_id = d.id

--- a/dbt/models/postgres/marts/mart_screener_expense.sql
+++ b/dbt/models/postgres/marts/mart_screener_expense.sql
@@ -1,0 +1,10 @@
+{{
+  config(
+    materialized='table',
+    description='Materialized mart for expense'
+  )
+}}
+
+
+SELECT *
+FROM {{ ref('stg_expenses') }}

--- a/dbt/models/postgres/staging/stg_expenses.sql
+++ b/dbt/models/postgres/staging/stg_expenses.sql
@@ -11,5 +11,4 @@ select
     ,d.white_label_id
     ,se.*
 from {{ source('django_apps', 'screener_expense') }} se
-left join {{ ref('stg_screens') }} d ON se.screen_id = d.id
-where se.screen_id in(d.id)
+inner join {{ ref('stg_screens') }} d ON se.screen_id = d.id

--- a/dbt/models/postgres/staging/stg_expenses.sql
+++ b/dbt/models/postgres/staging/stg_expenses.sql
@@ -5,10 +5,5 @@
   )
 }}
 
-select
-    d.id as screener_id
-    ,d.submission_date::date as submission_date
-    ,d.white_label_id
-    ,se.*
-from {{ source('django_apps', 'screener_expense') }} se
-inner join {{ ref('stg_screens') }} d ON se.screen_id = d.id
+select *
+from {{ source('django_apps', 'screener_expense') }}

--- a/dbt/models/postgres/staging/stg_expenses.sql
+++ b/dbt/models/postgres/staging/stg_expenses.sql
@@ -1,0 +1,15 @@
+{{
+  config(
+    materialized='view',
+    description='Expenses data'
+  )
+}}
+
+select
+    d.id as screener_id
+    ,d.submission_date::date as submission_date
+    ,d.white_label_id
+    ,se.*
+from {{ source('django_apps', 'screener_expense') }} se
+left join {{ ref('stg_screens') }} d ON se.screen_id = d.id
+where se.screen_id in(d.id)


### PR DESCRIPTION
Add `stg_expenses` and `mart_screener_expenses`.

Updated the LEFT JOIN in `stg_expenses` from `data.sql` to `stg_screens`. Since `mart_screener_data` now serves as the equivalent of `data.sql`, the previous join violated the stg → mart dependency rule.

Because `stg_expenses` is consumed directly in Looker Studio, it has been promoted to a mart (`mart_screener_expenses`) for better alignment and future extensibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New expense data models are now available, enabling enhanced tracking, analysis, and reporting of expense information across the platform.
  * A new staging view for raw expense records has been added to improve data consistency and make expense details more readily accessible for reporting and downstream use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->