### PR TITLE
ming/mfb-390-data-dbt-models-for-previous-benefits

### DIFF
--- a/dbt/models/postgres/intermediate/int_complete_screener_data.sql
+++ b/dbt/models/postgres/intermediate/int_complete_screener_data.sql
@@ -271,7 +271,7 @@ with base_table_1 as (
         pe.andcs_annual,
         pe.awd_medicaid_annual,
         pe.bca_annual,
-        pe.cccap_annual,
+        pe.ccap_annual,
         pe.cdhcs_annual,
         pe.cfhc_annual,
         pe.chp_annual,
@@ -413,7 +413,7 @@ base_table_2 as (
             + coalesce(andcs_annual, 0)
             + coalesce(awd_medicaid_annual, 0)
             + coalesce(bca_annual, 0)
-            + coalesce(cccap_annual, 0)
+            + coalesce(ccap_annual, 0)
             + coalesce(cdhcs_annual, 0)
             + coalesce(cfhc_annual, 0)
             + coalesce(chp_annual, 0)

--- a/dbt/models/postgres/intermediate/int_previous_benefits.sql
+++ b/dbt/models/postgres/intermediate/int_previous_benefits.sql
@@ -1,0 +1,59 @@
+{{ config(
+    materialized='view',
+    description='Base table for final previous benefits data query'
+) }}
+
+
+select
+    white_label_id
+    ,partner
+    ,sum(case when has_acp = true then 1 else 0 end) as acp
+    ,sum(case when has_andcs = true then 1 else 0 end) as andcs
+    ,sum(case when has_ccb = true then 1 else 0 end) as ccb
+    ,sum(case when has_ccap = true then 1 else 0 end) as ccap
+    ,sum(case when has_ccdf = true then 1 else 0 end) as ccdf
+    ,sum(case when has_cdhcs = true then 1 else 0 end) as cdhcs
+    ,sum(case when has_chp = true then 1 else 0 end) as chp
+    ,sum(case when has_chs = true then 1 else 0 end) as chs
+    ,sum(case when has_co_andso = true then 1 else 0 end) as co_andso
+    ,sum(case when has_coctc = true then 1 else 0 end) as coctc
+    ,sum(case when has_coeitc = true then 1 else 0 end) as coeitc
+    ,sum(case when has_cowap = true then 1 else 0 end) as cowap
+    ,sum(case when has_cpcr = true then 1 else 0 end) as cpcr
+    ,sum(case when has_csfp = true then 1 else 0 end) as csfp
+    ,sum(case when has_ctc = true then 1 else 0 end) as ctc
+    ,sum(case when has_dpp = true then 1 else 0 end) as dpp
+    ,sum(case when has_ede = true then 1 else 0 end) as ede
+    ,sum(case when has_eitc = true then 1 else 0 end) as eitc
+    ,sum(case when has_erc = true then 1 else 0 end) as erc
+    ,sum(case when has_fatc = true then 1 else 0 end) as fatc
+    ,sum(case when has_leap = true then 1 else 0 end) as leap
+    ,sum(case when has_lifeline = true then 1 else 0 end) as lifeline
+    ,sum(case when has_ma_eaedc = true then 1 else 0 end) as ma_eaedc
+    ,sum(case when has_ma_macfc = true then 1 else 0 end) as ma_macfc
+    ,sum(case when has_ma_maeitc = true then 1 else 0 end) as ma_maeitc
+    ,sum(case when has_ma_mbta = true then 1 else 0 end) as ma_mbta
+    ,sum(case when has_ma_ssp = true then 1 else 0 end) as ma_ssp
+    ,sum(case when has_medicaid = true then 1 else 0 end) as medicaid
+    ,sum(case when has_mydenver = true then 1 else 0 end) as mydenver
+    ,sum(case when has_nc_lieap = true then 1 else 0 end) as nc_lieap
+    ,sum(case when has_nccip = true then 1 else 0 end) as nccip
+    ,sum(case when has_ncscca = true then 1 else 0 end) as ncscca
+    ,sum(case when has_ncwap = true then 1 else 0 end) as ncwap
+    ,sum(case when has_nfp = true then 1 else 0 end) as nfp
+    ,sum(case when has_nslp = true then 1 else 0 end) as nslp
+    ,sum(case when has_oap = true then 1 else 0 end) as oap
+    ,sum(case when has_pell_grant = true then 1 else 0 end) as pell_grant
+    ,sum(case when has_rag = true then 1 else 0 end) as rag
+    ,sum(case when has_rtdlive = true then 1 else 0 end) as rtdlive
+    ,sum(case when has_section_8 = true then 1 else 0 end) as section_8
+    ,sum(case when has_snap = true then 1 else 0 end) as snap
+    ,sum(case when has_ssi = true then 1 else 0 end) as ssi
+    ,sum(case when has_sunbucks = true then 1 else 0 end) as sunbucks
+    ,sum(case when has_tanf = true then 1 else 0 end) as tanf
+    ,sum(case when has_ubp = true then 1 else 0 end) as ubp
+    ,sum(case when has_upk = true then 1 else 0 end) as upk
+    ,sum(case when has_va = true then 1 else 0 end) as va
+    ,sum(case when has_wic = true then 1 else 0 end) as wic
+from {{ ref('int_complete_screener_data') }}
+group by white_label_id, partner

--- a/dbt/models/postgres/marts/mart_previous_benefits.sql
+++ b/dbt/models/postgres/marts/mart_previous_benefits.sql
@@ -1,7 +1,7 @@
 {{
   config(
     materialized='table',
-    description='Materialized mart for previous beneftis'
+    description='Materialized mart for previous benefits'
   )
 }}
 

--- a/dbt/models/postgres/marts/mart_previous_benefits.sql
+++ b/dbt/models/postgres/marts/mart_previous_benefits.sql
@@ -6,7 +6,13 @@
 }}
 
 select
-    unnest(array[
+    t.benefit as benefit,
+    t.count as count,
+    pb.white_label_id,
+    pb.partner
+from {{ ref('int_previous_benefits') }} pb
+cross join lateral unnest(
+    array[
         'ACP'
         ,'ANDCS'
         ,'CCB'
@@ -55,57 +61,55 @@ select
         ,'UPK'
         ,'VA'
         ,'WIC'
-        ]) as Benefit
-    ,unnest(array[
-        acp
-        ,andcs
-        ,ccb
-        ,ccap
-        ,ccdf
-        ,cdhcs
-        ,chp
-        ,chs
-        ,co_andso
-        ,coctc
-        ,coeitc
-        ,cowap
-        ,cpcr
-        ,csfp
-        ,ctc
-        ,dpp
-        ,ede
-        ,eitc
-        ,erc
-        ,fatc
-        ,leap
-        ,lifeline
-        ,ma_eaedc
-        ,ma_macfc
-        ,ma_maeitc
-        ,ma_mbta
-        ,ma_ssp
-        ,medicaid
-        ,mydenver
-        ,nc_lieap
-        ,nccip
-        ,ncscca
-        ,ncwap
-        ,nfp
-        ,nslp
-        ,oap
-        ,pell_grant
-        ,rag
-        ,rtdlive
-        ,section_8
-        ,snap
-        ,ssi
-        ,sunbucks
-        ,tanf
-        ,ubp
-        ,upk
-        ,va
-        ,wic
-        ]) as Count
-    ,white_label_id
-    ,partner
-from {{ ref('int_previous_benefits') }}
+        ],
+    array[
+        pb.acp
+        ,pb.andcs
+        ,pb.ccb
+        ,pb.ccap
+        ,pb.ccdf
+        ,pb.cdhcs
+        ,pb.chp
+        ,pb.chs
+        ,pb.co_andso
+        ,pb.coctc
+        ,pb.coeitc
+        ,pb.cowap
+        ,pb.cpcr
+        ,pb.csfp
+        ,pb.ctc
+        ,pb.dpp
+        ,pb.ede
+        ,pb.eitc
+        ,pb.erc
+        ,pb.fatc
+        ,pb.leap
+        ,pb.lifeline
+        ,pb.ma_eaedc
+        ,pb.ma_macfc
+        ,pb.ma_maeitc
+        ,pb.ma_mbta
+        ,pb.ma_ssp
+        ,pb.medicaid
+        ,pb.mydenver
+        ,pb.nc_lieap
+        ,pb.nccip
+        ,pb.ncscca
+        ,pb.ncwap
+        ,pb.nfp
+        ,pb.nslp
+        ,pb.oap
+        ,pb.pell_grant
+        ,pb.rag
+        ,pb.rtdlive
+        ,pb.section_8
+        ,pb.snap
+        ,pb.ssi
+        ,pb.sunbucks
+        ,pb.tanf
+        ,pb.ubp
+        ,pb.upk
+        ,pb.va
+        ,pb.wic
+    ]
+) as t(benefit, count)

--- a/dbt/models/postgres/marts/mart_previous_benefits.sql
+++ b/dbt/models/postgres/marts/mart_previous_benefits.sql
@@ -1,0 +1,111 @@
+{{
+  config(
+    materialized='table',
+    description='Materialized mart for previous beneftis'
+  )
+}}
+
+select
+    unnest(array[
+        'ACP'
+        ,'ANDCS'
+        ,'CCB'
+        ,'CCAP'
+        ,'CCDF'
+        ,'CDHCS'
+        ,'CHP'
+        ,'CHS'
+        ,'CO ANDSO'
+        ,'COCTC'
+        ,'COEITC'
+        ,'COWAP'
+        ,'CPCR'
+        ,'CSFP'
+        ,'CTC'
+        ,'DPP'
+        ,'EDE'
+        ,'EITC'
+        ,'ERC'
+        ,'FATC'
+        ,'LEAP'
+        ,'Lifeline'
+        ,'MA EAEDC'
+        ,'MA CFC'
+        ,'MA EITC'
+        ,'MA MBTA'
+        ,'MA SSP'
+        ,'Medicaid'
+        ,'My Denver'
+        ,'NC LIEAP'
+        ,'NCCIP'
+        ,'NC SCCA'
+        ,'NC WAP'
+        ,'NFP'
+        ,'NSLP'
+        ,'OAP'
+        ,'Pell Grant'
+        ,'RAG'
+        ,'RTD Live'
+        ,'Section 8'
+        ,'SNAP'
+        ,'SSI'
+        ,'Sunbucks'
+        ,'TANF'
+        ,'UBP'
+        ,'UPK'
+        ,'VA'
+        ,'WIC'
+        ]) as Benefit
+    ,unnest(array[
+        acp
+        ,andcs
+        ,ccb
+        ,ccap
+        ,ccdf
+        ,cdhcs
+        ,chp
+        ,chs
+        ,co_andso
+        ,coctc
+        ,coeitc
+        ,cowap
+        ,cpcr
+        ,csfp
+        ,ctc
+        ,dpp
+        ,ede
+        ,eitc
+        ,erc
+        ,fatc
+        ,leap
+        ,lifeline
+        ,ma_eaedc
+        ,ma_macfc
+        ,ma_maeitc
+        ,ma_mbta
+        ,ma_ssp
+        ,medicaid
+        ,mydenver
+        ,nc_lieap
+        ,nccip
+        ,ncscca
+        ,ncwap
+        ,nfp
+        ,nslp
+        ,oap
+        ,pell_grant
+        ,rag
+        ,rtdlive
+        ,section_8
+        ,snap
+        ,ssi
+        ,sunbucks
+        ,tanf
+        ,ubp
+        ,upk
+        ,va
+        ,wic
+        ]) as Count
+    ,white_label_id
+    ,partner
+from {{ ref('int_previous_benefits') }}

--- a/dbt/models/postgres/staging/stg_program_eligibility.sql
+++ b/dbt/models/postgres/staging/stg_program_eligibility.sql
@@ -11,7 +11,7 @@ select
     ,sum(case when name_abbreviated = 'andcs' then estimated_value ELSE 0 end) as andcs_annual
     ,sum(case when name_abbreviated = 'awd_medicaid' then estimated_value else 0 end) as awd_medicaid_annual
     ,sum(case when name_abbreviated = 'bca' then estimated_value else 0 end) as bca_annual
-    ,sum(case when name_abbreviated = 'cccap' then estimated_value else 0 end) as cccap_annual
+    ,sum(case when name_abbreviated = 'ccap' then estimated_value else 0 end) as ccap_annual
     ,sum(case when name_abbreviated = 'cdhcs' then estimated_value else 0 end) as cdhcs_annual
     ,sum(case when name_abbreviated = 'cfhc' then estimated_value else 0 end) as cfhc_annual
     ,sum(case when name_abbreviated = 'chp' then estimated_value else 0 end) as chp_annual

--- a/dbt/seeds/referrer_codes.csv
+++ b/dbt/seeds/referrer_codes.csv
@@ -4,6 +4,8 @@ null,No Partner
 211co,2-1-1 Colorado
 211nc,2-1-1 North Carolina
 achs,Adams County Human Services
+achd,Adams County Health Department
+achdchw,Adams County Health Department - Community Health Workers
 achsshare,Adams County Human Services
 acph,Arapahoe County Public Health
 acphnlp,Arapahoe County Public Health
@@ -22,6 +24,7 @@ bgcmd,Boys & Girls Club of Metro Denver
 bia,Benefits in Action
 blueprint,Blueprint NC
 brightbytext,Bright by Text
+broomfield,City and County of Broomfield
 BWF-46951-TL,Builds with Families
 BWFProspective,Builds with Families
 BWFReferrals,Builds with Families


### PR DESCRIPTION
This PR added 

- int_previous_benefits.sql 
- mart_previous_benefits.sql

Updated `cccap` to `ccap` in below files,

- int_complete_screener_data.sql
- stg_program_eligibility.sql

Also included 3 new referrer codes for
seeds/referrer_codes.csv

The output of this new added files output 336 rows of previous benefits while the `data_previous_benefits.sql` outputs 288 rows. After comparing the data. I believe this new version is more accurate. 

Example: 
Testing with local data using `uuid` = "7ec4b117-8cf7-4444-95c5-c273272abc47".
In the output of `base_table_1`,  the `partner` column shows  "Other" in the existing materialized view, whereas in the new version it shows "Blueprint NC". 
Look this `uuid` up in `screener_screen` table, the `referral_source` shows "blueprint". This is more accurate.
Since the new version has more accurate partners, the final output of previous benefits has more rows.

This is how the latest graph looks like,
<img width="1313" height="613" alt="mart_previous_benefits" src="https://github.com/user-attachments/assets/7efc21f8-1400-4cf8-9cc8-4f3cb66ba2d7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a program eligibility field name to ensure consistent naming across models.

* **New Features**
  * Added a new aggregated view that counts prior benefit flags per account/partner.
  * Added a materialized mart that transforms those aggregates into a tabular benefit-by-count report for reporting and analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->