### PR TITLE
Update partner handling and add urls

### DIFF
--- a/dbt/models/postgres/intermediate/int_complete_screener_data.sql
+++ b/dbt/models/postgres/intermediate/int_complete_screener_data.sql
@@ -27,7 +27,7 @@ with base_table_1 as (
             when ss.referrer_code is not null and trim(ss.referrer_code) <> '' then
                 case
                     when ss.referral_source is null or trim(ss.referral_source) = '' then drc1.partner
-                    when trim(ss.referral_source) = trim(ss.referrer_code) then drc1.partner
+                    when trim(ss.referral_source) = trim(ss.referrer_code) then coalesce(drc1.partner, 'Other')
                     when trim(ss.referral_source) <> trim(ss.referrer_code) then
                         case
                             when drc2.referrer_code is not null then concat(drc1.partner,', ',drc2.partner)

--- a/dbt/models/postgres/marts/mart_screener_data.sql
+++ b/dbt/models/postgres/marts/mart_screener_data.sql
@@ -1,7 +1,8 @@
 {{
   config(
     materialized='table',
-    description='Materialized mart for screener analytics - optimized for dashboard performance'
+    description='Materialized mart for screener analytics - optimized for dashboard performance',
+    post_hook="{{ setup_white_label_rls(this.name) }}"
   )
 }}
 

--- a/dbt/models/postgres/marts/mart_screener_expense.sql
+++ b/dbt/models/postgres/marts/mart_screener_expense.sql
@@ -1,7 +1,8 @@
 {{
   config(
     materialized='table',
-    description='Materialized mart for expenses data'
+    description='Materialized mart for expenses data',
+    post_hook="{{ setup_white_label_rls(this.name) }}"
   )
 }}
 


### PR DESCRIPTION
While reviewing another PR, I found that `partner` may return `null` instead of `Other`. 
This PR resolves that and adds RLS to the existing `data` and `expense` mart views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved data quality for partner information in screener records with enhanced fallback handling for missing values.

* **Chores**
  * Applied security enhancements to data access controls across screener and expense datasets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->