### PR TITLE
MFB-380: Data: White label dashboard - Create pages/tabs

### DIFF
--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -157,11 +157,41 @@ resource "metabase_collection" "tenant_collection_co" {
   depends_on = [metabase_collection.tenant_collection_nc]
 }
 
+resource "metabase_collection" "tenant_collection_tx" {
+  name       = "Texas"
+  depends_on = [metabase_collection.tenant_collection_co]
+}
+
+resource "metabase_collection" "tenant_collection_il" {
+  name       = "Illinois"
+  depends_on = [metabase_collection.tenant_collection_tx]
+}
+
+resource "metabase_collection" "tenant_collection_ma" {
+  name       = "Massachusetts"
+  depends_on = [metabase_collection.tenant_collection_il]
+}
+
+resource "metabase_collection" "tenant_collection_cesn" {
+  name       = "CESN"
+  depends_on = [metabase_collection.tenant_collection_ma]
+}
+
+resource "metabase_collection" "tenant_collection_co_tax_calculator" {
+  name       = "CO Tax Calculator"
+  depends_on = [metabase_collection.tenant_collection_cesn]
+}
+
 # Map for other resources to reference tenant collections by key
 locals {
   tenant_collection_map = {
-    nc = metabase_collection.tenant_collection_nc
-    co = metabase_collection.tenant_collection_co
+    nc                = metabase_collection.tenant_collection_nc
+    co                = metabase_collection.tenant_collection_co
+    tx                = metabase_collection.tenant_collection_tx
+    il                = metabase_collection.tenant_collection_il
+    ma                = metabase_collection.tenant_collection_ma
+    cesn              = metabase_collection.tenant_collection_cesn
+    co_tax_calculator = metabase_collection.tenant_collection_co_tax_calculator
   }
 }
 
@@ -265,12 +295,22 @@ resource "metabase_dashboard" "analytics" {
 resource "metabase_dashboard" "tenant_analytics" {
   for_each = var.tenants
 
-  name       = "${each.value.display_name} Dashboard"
+  name          = "${each.value.display_name} Dashboard"
   collection_id = tonumber(local.tenant_collection_map[each.key].id)
+
+  tabs_json = jsonencode([
+    { id = 1, name = "Google Analytics" },
+    { id = 2, name = "All-Time Performance" },
+    { id = 3, name = "Last 30 Days Performance" },
+    { id = 4, name = "Households" },
+    { id = 5, name = "Benefits & Immediate Needs" }
+  ])
 
   cards_json = jsonencode([
     {
       card_id = tonumber(metabase_card.tenant_screen_count[each.key].id)
+      # Assigning existing card to "All-Time Performance" tab (ID 2)
+      dashboard_tab_id = 2
       row = 0
       col = 0
       size_x = 6

--- a/dashboards/terraform.tfvars.example
+++ b/dashboards/terraform.tfvars.example
@@ -19,7 +19,27 @@ tenant_db_credentials = {
   }
   co = {
     username = "co" 
-    password = "your_password"  # CO user password (update this)
+    password = "your_password"  # CO user password
+  }
+  tx = {
+    username = "tx"
+    password = "your_password"  # TX user password
+  }
+  il = {
+    username = "il"
+    password = "your_password"  # IL user password
+  }
+  ma = {
+    username = "ma"
+    password = "your_password"  # MA user password
+  }
+  cesn = {
+    username = "cesn"
+    password = "your_password"  # CESN user password
+  }
+  co_tax_calculator = {
+    username = "co_tax_calculator"
+    password = "your_password"  # CO Tax Calculator user password
   }
 }
 
@@ -32,6 +52,26 @@ tenants = {
   co = {
     name         = "co"
     display_name = "Colorado"
+  }
+  tx = {
+    name         = "tx"
+    display_name = "Texas"
+  }
+  il = {
+    name         = "il"
+    display_name = "Illinois"
+  }
+  ma = {
+    name         = "ma"
+    display_name = "Massachusetts"
+  }
+  cesn = {
+    name         = "cesn"
+    display_name = "CESN"
+  }
+  co_tax_calculator = {
+    name         = "co_tax_calculator"
+    display_name = "CO Tax Calculator"
   }
 }
 

--- a/dashboards/variables.tf
+++ b/dashboards/variables.tf
@@ -40,6 +40,26 @@ variable "tenants" {
       name         = "co"
       display_name = "Colorado"
     }
+    tx = {
+      name         = "tx"
+      display_name = "Texas"
+    }
+    il = {
+      name         = "il"
+      display_name = "Illinois"
+    }
+    ma = {
+      name         = "ma"
+      display_name = "Massachusetts"
+    }
+    cesn = {
+      name         = "cesn"
+      display_name = "CESN"
+    }
+    co_tax_calculator = {
+      name         = "co_tax_calculator"
+      display_name = "CO Tax Calculator"
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes: #[MFB-380](https://linear.app/myfriendben/issue/MFB-380/data-white-label-dashboard-create-pagestabs)

Creates a skeleton dashboard structure in Metabase with tabs matching the current Looker Studio tabs. Also added all existing white label tenants.

## Changes

- Dashboard Tabs: added tabs_json to metabase_dashboard.tenant_analytics with 5 tabs.
- New Tenants: added Metabase collections and tenant configurations - each new tenant automatically gets its own dashboard with all 5 tabs.


<img width="1262" height="566" alt="Screen Shot 2026-02-18 at 4 16 33 PM" src="https://github.com/user-attachments/assets/54831e1d-b565-4a44-93ee-7fb2b6631dc7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for five new tenant regions: Texas, Illinois, Massachusetts, CESN, and CO Tax Calculator
  * Added new dashboard tabs: Google Analytics, All-Time Performance, Last 30 Days Performance, Households, and Benefits & Immediate Needs
  * Enhanced dashboard organization with refined card placement and tab assignments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->