### PR TITLE
feat: enforce white label RLS post-hook on mart models (MFB-656)

### DIFF
--- a/.github/workflows/rls-check.yml
+++ b/.github/workflows/rls-check.yml
@@ -18,7 +18,7 @@ jobs:
           MARTS_DIR="dbt/models/postgres/marts"
           non_compliant=()
 
-          files=("$MARTS_DIR"/*.sql)
+          mapfile -t files < <(find "$MARTS_DIR" -name "*.sql" -type f)
           if [ ${#files[@]} -eq 0 ]; then
             echo "ℹ️  No mart models found under $MARTS_DIR"
             exit 0
@@ -27,13 +27,13 @@ jobs:
             model=$(basename "$file" .sql)
 
             # Allow explicit opt-out via 'no-rls' tag
-            if grep -q "no-rls" "$file"; then
+            if grep -qE "(tags\s*=\s*\[.*'no-rls'|'no-rls'.*tags\s*=\s*\[)" "$file"; then
               echo "ℹ️  $model opted out of RLS via 'no-rls' tag"
               continue
             fi
 
             # Check for the required post-hook
-            if ! grep -q "setup_white_label_rls" "$file"; then
+            if ! grep -v '^\s*--' "$file" | grep -q "setup_white_label_rls"; then
               non_compliant+=("$model")
             fi
           done

--- a/.github/workflows/rls-check.yml
+++ b/.github/workflows/rls-check.yml
@@ -1,0 +1,51 @@
+name: RLS Post-Hook Enforcement
+
+on:
+  pull_request:
+    paths:
+      - "dbt/models/postgres/marts/**"
+
+jobs:
+  check-rls-hooks:
+    name: Check mart models for RLS post-hook
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check mart models for RLS post-hook
+        run: |
+          MARTS_DIR="dbt/models/postgres/marts"
+          non_compliant=()
+
+          for file in "$MARTS_DIR"/*.sql; do
+            model=$(basename "$file" .sql)
+
+            # Allow explicit opt-out via 'no-rls' tag
+            if grep -q "no-rls" "$file"; then
+              echo "ℹ️  $model opted out of RLS via 'no-rls' tag"
+              continue
+            fi
+
+            # Check for the required post-hook
+            if ! grep -q "setup_white_label_rls" "$file"; then
+              non_compliant+=("$model")
+            fi
+          done
+
+          if [ ${#non_compliant[@]} -gt 0 ]; then
+            echo ""
+            echo "🚨 RLS ENFORCEMENT FAILURE"
+            echo "The following mart models are missing the required white label RLS post-hook:"
+            for model in "${non_compliant[@]}"; do
+              echo "  - $model"
+            done
+            echo ""
+            echo "To fix, add this to each model's config block:"
+            echo '  post_hook="{{ setup_white_label_rls(this.name) }}"'
+            echo ""
+            echo "If a model genuinely doesn't need RLS, add the tag 'no-rls':"
+            echo "  tags=['no-rls']"
+            exit 1
+          fi
+
+          echo "✅ All mart models have the required RLS post-hook."

--- a/.github/workflows/rls-check.yml
+++ b/.github/workflows/rls-check.yml
@@ -14,10 +14,16 @@ jobs:
 
       - name: Check mart models for RLS post-hook
         run: |
+          shopt -s nullglob
           MARTS_DIR="dbt/models/postgres/marts"
           non_compliant=()
 
-          for file in "$MARTS_DIR"/*.sql; do
+          files=("$MARTS_DIR"/*.sql)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "ℹ️  No mart models found under $MARTS_DIR"
+            exit 0
+          fi
+          for file in "${files[@]}"; do
             model=$(basename "$file" .sql)
 
             # Allow explicit opt-out via 'no-rls' tag

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -3,6 +3,9 @@ version: 1.0.0
 profile: benefits
 require-dbt-version: ">=1.7.0,<2.0.0"
 
+on-run-end: 
+  - "{{ enforce_rls_on_marts() }}"
+
 model-paths: ["models"]
 analysis-paths: ["analyses"]
 test-paths: ["tests"]

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -3,7 +3,7 @@ version: 1.0.0
 profile: benefits
 require-dbt-version: ">=1.7.0,<2.0.0"
 
-on-run-end: 
+on-run-start: 
   - "{{ enforce_rls_on_marts() }}"
 
 model-paths: ["models"]

--- a/dbt/macros/enforce_rls_post_hook.sql
+++ b/dbt/macros/enforce_rls_post_hook.sql
@@ -20,9 +20,8 @@
     {% for node in graph.nodes.values() %}
       {# Only check postgres mart models #}
       {% if node.resource_type == 'model'
-         and node.fqn | length >= 3
-         and node.fqn[1] == 'postgres'
-         and node.fqn[2] == 'marts' %}
+         and node.path is string
+         and node.path.startswith('postgres/marts/') %}
 
         {# Allow explicit opt-out via 'no-rls' tag #}
         {% if 'no-rls' in node.tags %}

--- a/dbt/macros/enforce_rls_post_hook.sql
+++ b/dbt/macros/enforce_rls_post_hook.sql
@@ -2,7 +2,7 @@
   Macro: enforce_rls_on_marts
 
   Enforces that all postgres mart models include the white label RLS post-hook
-  (setup_white_label_rls). This macro is called via the on-run-end hook in
+  (setup_white_label_rls). This macro is called via the on-run-start hook in
   dbt_project.yml and will raise a compilation error if any mart model under
   models/postgres/marts/ is missing the required post-hook. 
 #}

--- a/dbt/macros/enforce_rls_post_hook.sql
+++ b/dbt/macros/enforce_rls_post_hook.sql
@@ -1,0 +1,81 @@
+{#
+  Macro: enforce_rls_on_marts
+
+  Enforces that all postgres mart models include the white label RLS post-hook
+  (setup_white_label_rls). This macro is called via the on-run-end hook in
+  dbt_project.yml and will raise a compilation error if any mart model under
+  models/postgres/marts/ is missing the required post-hook.
+
+  How it works:
+    - Skips enforcement for non-postgres targets (e.g. BigQuery).
+    - Iterates over all compiled graph nodes, filtering for mart models
+      in the models/postgres/marts/ directory.
+    - Inspects each model's 'post-hook' config for the presence of
+      'setup_white_label_rls'.
+    - Models can opt out by adding the tag 'no-rls' (e.g. tags=['no-rls']).
+    - Collects non-compliant models and raises a clear error listing them.
+
+  Usage:
+    Added as an on-run-end hook in dbt_project.yml:
+      on-run-end:
+        - "{{ enforce_rls_on_marts() }}"
+
+  Notes:
+    - The {% if execute %} guard is required because the graph object is only
+      available during execution, not during parsing.
+    - dbt stores hooks under the hyphenated key 'post-hook' (not 'post_hook')
+      in node.config.
+    - Jinja's namespace() is used to work around for-loop variable scoping.
+#}
+
+{% macro enforce_rls_on_marts() %}
+  {# Only enforce when running against postgres #}
+  {% if target.type != 'postgres' %}
+    {{ return('') }}
+  {% endif %}
+
+  {% set non_compliant = [] %}
+
+  {% if execute %}
+    {% for node in graph.nodes.values() %}
+      {# Only check postgres mart models #}
+      {% if node.resource_type == 'model'
+         and node.fqn | length >= 3
+         and node.fqn[1] == 'postgres'
+         and node.fqn[2] == 'marts' %}
+
+        {# Allow explicit opt-out via 'no-rls' tag #}
+        {% if 'no-rls' in node.tags %}
+          {{ log("ℹ️  " ~ node.name ~ " opted out of RLS via 'no-rls' tag", info=true) }}
+        {% else %}
+          {# Check if post-hook contains setup_white_label_rls #}
+          {# Note: dbt stores hooks under the hyphenated key 'post-hook' in node.config #}
+          {% set hooks = node.config.get('post-hook', []) %}
+          {% set ns = namespace(has_rls_hook=false) %}
+          {% for hook in hooks %}
+            {% if 'setup_white_label_rls' in hook.sql %}
+              {% set ns.has_rls_hook = true %}
+            {% endif %}
+          {% endfor %}
+
+          {% if not ns.has_rls_hook %}
+            {% do non_compliant.append(node.name) %}
+          {% endif %}
+        {% endif %}
+
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+
+  {% if non_compliant | length > 0 %}
+    {{ exceptions.raise_compiler_error(
+      "\n🚨 RLS ENFORCEMENT FAILURE\n"
+      ~ "The following mart models are missing the required white label RLS post-hook:\n\n  - "
+      ~ non_compliant | join('\n  - ')
+      ~ "\n\nTo fix, add this to each model's config block:\n"
+      ~ '  post_hook="{{ setup_white_label_rls(this.name) }}"\n\n'
+      ~ "If a model genuinely doesn't need RLS, add the tag 'no-rls':\n"
+      ~ "  tags=['no-rls']\n"
+    ) }}
+  {% endif %}
+{% endmacro %}

--- a/dbt/macros/enforce_rls_post_hook.sql
+++ b/dbt/macros/enforce_rls_post_hook.sql
@@ -31,7 +31,8 @@
           {% set hooks = node.config.get('post-hook', []) %}
           {% set ns = namespace(has_rls_hook=false) %}
           {% for hook in hooks %}
-            {% if 'setup_white_label_rls' in hook.sql %}
+            {% set hook_sql = hook.sql if hook.sql is not none else hook %}
+            {% if hook_sql is string and 'setup_white_label_rls' in hook_sql %}
               {% set ns.has_rls_hook = true %}
             {% endif %}
           {% endfor %}

--- a/dbt/macros/enforce_rls_post_hook.sql
+++ b/dbt/macros/enforce_rls_post_hook.sql
@@ -5,27 +5,7 @@
   (setup_white_label_rls). This macro is called via the on-run-end hook in
   dbt_project.yml and will raise a compilation error if any mart model under
   models/postgres/marts/ is missing the required post-hook.
-
-  How it works:
-    - Skips enforcement for non-postgres targets (e.g. BigQuery).
-    - Iterates over all compiled graph nodes, filtering for mart models
-      in the models/postgres/marts/ directory.
-    - Inspects each model's 'post-hook' config for the presence of
-      'setup_white_label_rls'.
-    - Models can opt out by adding the tag 'no-rls' (e.g. tags=['no-rls']).
-    - Collects non-compliant models and raises a clear error listing them.
-
-  Usage:
-    Added as an on-run-end hook in dbt_project.yml:
-      on-run-end:
-        - "{{ enforce_rls_on_marts() }}"
-
-  Notes:
-    - The {% if execute %} guard is required because the graph object is only
-      available during execution, not during parsing.
-    - dbt stores hooks under the hyphenated key 'post-hook' (not 'post_hook')
-      in node.config.
-    - Jinja's namespace() is used to work around for-loop variable scoping.
+ 
 #}
 
 {% macro enforce_rls_on_marts() %}

--- a/dbt/macros/enforce_rls_post_hook.sql
+++ b/dbt/macros/enforce_rls_post_hook.sql
@@ -31,7 +31,7 @@
           {% set hooks = node.config.get('post-hook', []) %}
           {% set ns = namespace(has_rls_hook=false) %}
           {% for hook in hooks %}
-            {% set hook_sql = hook.sql if hook.sql is not none else hook %}
+            {% set hook_sql = hook.sql if hook.sql is defined else hook %}
             {% if hook_sql is string and 'setup_white_label_rls' in hook_sql %}
               {% set ns.has_rls_hook = true %}
             {% endif %}

--- a/dbt/macros/enforce_rls_post_hook.sql
+++ b/dbt/macros/enforce_rls_post_hook.sql
@@ -4,8 +4,7 @@
   Enforces that all postgres mart models include the white label RLS post-hook
   (setup_white_label_rls). This macro is called via the on-run-end hook in
   dbt_project.yml and will raise a compilation error if any mart model under
-  models/postgres/marts/ is missing the required post-hook.
- 
+  models/postgres/marts/ is missing the required post-hook. 
 #}
 
 {% macro enforce_rls_on_marts() %}

--- a/dbt/models/postgres/marts/mart_income.sql
+++ b/dbt/models/postgres/marts/mart_income.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized='table',
-    description='Mart model for income data with row-level security by white_label_id'
-    
+    description='Mart model for income data with row-level security by white_label_id',
+    post_hook="{{ setup_white_label_rls(this.name) }}"
 ) }}
 
 SELECT

--- a/dbt/models/postgres/marts/mart_income.sql
+++ b/dbt/models/postgres/marts/mart_income.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized='table',
-    description='Mart model for income data with row-level security by white_label_id',
-    post_hook="{{ setup_white_label_rls(this.name) }}"
+    description='Mart model for income data with row-level security by white_label_id'
+    
 ) }}
 
 SELECT

--- a/dbt/models/postgres/marts/mart_previous_benefits.sql
+++ b/dbt/models/postgres/marts/mart_previous_benefits.sql
@@ -1,6 +1,7 @@
 {{
   config(
     materialized='table',
+    post_hook="{{ setup_white_label_rls(this.name) }}",
     description='Materialized mart for previous benefits'
   )
 }}


### PR DESCRIPTION
## Context & Motivation

-   Fix: [MFB-656](https://linear.app/myfriendben/issue/MFB-656/data-enforce-white-label-rls-post-hook-on-mart-models)

- Adds automated enforcement to ensure all postgres mart models include the white label RLS post-hook 

(setup_white_label_rls)

    

## Problem

-   There was no mechanism to prevent a developer from adding a new mart model (or modifying an existing one) without including the required 
`post_hook="{{ setup_white_label_rls(this.name) }}". `
This could lead to data leaking across white label tenants.

-   `mart_previous_benefits.sql ` was the only existing mart model missing this hook.

## Changes Made

  Added `enforce_rls_post_hook.sql` file (new sql file) — `on-run-start `macro that:
  

-   Iterates over all compiled graph nodes filtered to models/postgres/marts/
-   Checks each model's post-hook config for `setup_white_label_rls`
-   Raises a clear error listing non-compliant models with fix instructions
-   Supports no-rls tag opt-out for models that genuinely don't need RLS
-   Only runs against the postgres target (skips BigQuery)
-   `dbt_project.yml `— Changed hook from on-run-end to on-run-start. Previously, mart tables could be materialized in postgres without RLS protection before the error fired. Now the build fails before any model executes.

  
  `mart_previous_benefits.sql` — Added the missing `post_hook="{{ setup_white_label_rls(this.name) }}"`

### New: Pre-merge GitHub Actions check (`.github/workflows/rls-check.yml`)
Adds a lightweight CI check that triggers on PRs touching mart models.
Statically scans `dbt/models/postgres/marts/*.sql` for the required
`setup_white_label_rls` post-hook with no database connection needed.
Respects the `no-rls` opt-out tag. This catches missing hooks before
merge rather than waiting for deployment to fail.

### Enforcement layers (after this PR)
| Layer | When | Mechanism |
|---|---|---|
| GitHub Actions | PR open/update | Static file scan |
| `on-run-start` macro | Deploy time | dbt graph check, fails before models run |
| PR review | PR review | Human backstop |


## Testing

  1. Verify the build passes with all hooks in place
  dbt build --target postgres
  
  
  Expected for now: PASS=99 WARN=0 ERROR=0, Completed successfully
  
  2. Verify enforcement catches a missing hook
  Remove the post_hook line from any mart model (e.g., mart_previous_benefits.sql)
  then run `dbt build --target Postgres` command.
Expected: build fails immediately with  RLS ENFORCEMENT FAILURE listing the model, before any tables are created.


3. Verify the GitHub Actions pre-merge check
Open a PR that adds or modifies a file in dbt/models/postgres/marts/ without the post-hook.
Expected: the RLS Post-Hook Enforcement check fails with  RLS ENFORCEMENT FAILURE.

## Screenshot

Screenshot after testing by removing RLS protection in mart_income.sql file to test pre-merge checks.

<img width="633" height="641" alt="Screenshot 2026-02-24 at 2 54 13 PM" src="https://github.com/user-attachments/assets/5b16e230-6bcf-4d55-9153-532cab4f7a05" />

<img width="892" height="674" alt="Screenshot 2026-02-24 at 2 44 57 PM" src="https://github.com/user-attachments/assets/8a89ec1c-289c-4177-a4d2-b1a7875f25cc" />

## Deployment

- Post-deployment scripts needed: None
- Production config updates: None
- Admin updates needed: None
- Notify team/users of: None

## Notes for Reviewers

- Know limitations: None
- Future considerations:

The workflow will run and show a pass/fail status on the PR, but it won't block merging on its own.

To make it block merging, a repo admin needs to configure it as a required status check in GitHub:

`Settings → Branches → Branch protection rules → (edit rule for main) → Require status checks to pass before merging → search for Check mart models for RLS post-hook → add it`

Once that's set, GitHub will prevent the "Merge" button from being clickable until the check passes.

Additionally, I would like to suggest adding a default PR description template to this data-queries repository, similar to what we have in the benefits-api and benefits-calculator repositories. When creating a PR or pushing changes, it would be helpful if sections such as ‘Context & Motivation,’ ‘Changes,’ ‘Screenshots,’ and other relevant headings were automatically included in the description.I believe this can be configured in the repository settings.

I don't have access to change setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project config extended with additional top-level path settings and per-target model materializations; default materialization set to view.

* **Security**
  * Added an on-run-start enforcement that verifies mart models include a post-deploy RLS setup, with an opt-out tag and remediation guidance.
  * One mart had the RLS post-deploy hook added; another had it removed.

* **CI**
  * New workflow validates PRs to ensure mart models include the required RLS post-deploy hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->