### PR TITLE
Downgraded Metabase image version to v0.56.19 in docker-compose.yml to fix provider errors

### DIFF
--- a/DEPLOYMENT_PLAN.md
+++ b/DEPLOYMENT_PLAN.md
@@ -50,7 +50,7 @@ exec /app/run_metabase.sh
 
 ```dockerfile
 # dashboards/Dockerfile.heroku
-FROM metabase/metabase:v0.56.19.x
+FROM metabase/metabase:v0.56.19
 COPY dashboards/heroku-entrypoint.sh /app/heroku-entrypoint.sh
 RUN chmod +x /app/heroku-entrypoint.sh
 CMD ["/app/heroku-entrypoint.sh"]
@@ -496,7 +496,7 @@ Terraform variables are passed as `TF_VAR_` environment variables. Use GitHub En
 
 ### Terraform Provider Notes
 
-- **Pin versions:** Keep `flovouin/metabase ~> 0.14` and `metabase/metabase:v0.56.19.x`. Test compatibility before upgrading either — the Metabase API is unversioned and can break between releases.
+- **Pin versions:** Keep `flovouin/metabase ~> 0.14` and `metabase/metabase:v0.56.19`. Test compatibility before upgrading either — the Metabase API is unversioned and can break between releases.
 - **State file security:** Terraform state stores all variable values in plaintext, including passwords. Terraform Cloud encrypts state at rest. If using GCS, ensure the bucket has appropriate access controls.
 
 ### Maintenance Note: CI Variable Coupling

--- a/DEPLOYMENT_PLAN.md
+++ b/DEPLOYMENT_PLAN.md
@@ -50,7 +50,7 @@ exec /app/run_metabase.sh
 
 ```dockerfile
 # dashboards/Dockerfile.heroku
-FROM metabase/metabase:v0.56.19
+FROM metabase/metabase:v0.56.19.x
 COPY dashboards/heroku-entrypoint.sh /app/heroku-entrypoint.sh
 RUN chmod +x /app/heroku-entrypoint.sh
 CMD ["/app/heroku-entrypoint.sh"]
@@ -496,7 +496,7 @@ Terraform variables are passed as `TF_VAR_` environment variables. Use GitHub En
 
 ### Terraform Provider Notes
 
-- **Pin versions:** Keep `flovouin/metabase ~> 0.14` and `metabase/metabase:v0.56.19`. Test compatibility before upgrading either — the Metabase API is unversioned and can break between releases.
+- **Pin versions:** Keep `flovouin/metabase ~> 0.14` and `metabase/metabase:v0.56.19.x`. Test compatibility before upgrading either — the Metabase API is unversioned and can break between releases.
 - **State file security:** Terraform state stores all variable values in plaintext, including passwords. Terraform Cloud encrypts state at rest. If using GCS, ensure the bucket has appropriate access controls.
 
 ### Maintenance Note: CI Variable Coupling

--- a/DEPLOYMENT_PLAN.md
+++ b/DEPLOYMENT_PLAN.md
@@ -50,7 +50,7 @@ exec /app/run_metabase.sh
 
 ```dockerfile
 # dashboards/Dockerfile.heroku
-FROM metabase/metabase:v0.57.11
+FROM metabase/metabase:v0.56.19
 COPY dashboards/heroku-entrypoint.sh /app/heroku-entrypoint.sh
 RUN chmod +x /app/heroku-entrypoint.sh
 CMD ["/app/heroku-entrypoint.sh"]
@@ -496,7 +496,7 @@ Terraform variables are passed as `TF_VAR_` environment variables. Use GitHub En
 
 ### Terraform Provider Notes
 
-- **Pin versions:** Keep `flovouin/metabase ~> 0.14` and `metabase/metabase:v0.57.11`. Test compatibility before upgrading either — the Metabase API is unversioned and can break between releases.
+- **Pin versions:** Keep `flovouin/metabase ~> 0.14` and `metabase/metabase:v0.56.19`. Test compatibility before upgrading either — the Metabase API is unversioned and can break between releases.
 - **State file security:** Terraform state stores all variable values in plaintext, including passwords. Terraform Cloud encrypts state at rest. If using GCS, ensure the bucket has appropriate access controls.
 
 ### Maintenance Note: CI Variable Coupling

--- a/dashboards/Dockerfile.heroku
+++ b/dashboards/Dockerfile.heroku
@@ -1,4 +1,4 @@
-FROM metabase/metabase:v0.56.19
+FROM metabase/metabase:v0.56.19.x
 COPY dashboards/heroku-entrypoint.sh /app/heroku-entrypoint.sh
 RUN chmod +x /app/heroku-entrypoint.sh
 CMD ["/app/heroku-entrypoint.sh"]

--- a/dashboards/Dockerfile.heroku
+++ b/dashboards/Dockerfile.heroku
@@ -1,4 +1,4 @@
-FROM metabase/metabase:v0.56.19.x
+FROM metabase/metabase:v0.56.19
 COPY dashboards/heroku-entrypoint.sh /app/heroku-entrypoint.sh
 RUN chmod +x /app/heroku-entrypoint.sh
 CMD ["/app/heroku-entrypoint.sh"]

--- a/dashboards/Dockerfile.heroku
+++ b/dashboards/Dockerfile.heroku
@@ -1,4 +1,4 @@
-FROM metabase/metabase:v0.57.11
+FROM metabase/metabase:v0.56.19
 COPY dashboards/heroku-entrypoint.sh /app/heroku-entrypoint.sh
 RUN chmod +x /app/heroku-entrypoint.sh
 CMD ["/app/heroku-entrypoint.sh"]

--- a/dashboards/docker-compose.yml
+++ b/dashboards/docker-compose.yml
@@ -2,7 +2,7 @@ name: mfb-dashboards
 
 services:
   metabase:
-    image: metabase/metabase:v0.57.11
+    image: metabase/metabase:v0.56.19
     container_name: metabase
     hostname: metabase
     ports:

--- a/dashboards/docker-compose.yml
+++ b/dashboards/docker-compose.yml
@@ -2,7 +2,7 @@ name: mfb-dashboards
 
 services:
   metabase:
-    image: metabase/metabase:v0.56.19.x
+    image: metabase/metabase:v0.56.19
     container_name: metabase
     hostname: metabase
     ports:

--- a/dashboards/docker-compose.yml
+++ b/dashboards/docker-compose.yml
@@ -2,7 +2,7 @@ name: mfb-dashboards
 
 services:
   metabase:
-    image: metabase/metabase:v0.56.19
+    image: metabase/metabase:v0.56.19.x
     container_name: metabase
     hostname: metabase
     ports:


### PR DESCRIPTION
## Summary

- Downgraded Metabase from v0.57.11 to v0.56.19.
- Reasoning: Metabase v0.57.0+ introduces MBQL 5, which causes "Inconsistent result" provider errors in the Terraform provider as it automatically reformats queries on the fly. v0.56.19 is the current stable baseline for this provider.


## Setup
Here are the steps to downgrade (important: these steps are needed if you already have a newer Metabase version setup - otherwise you may run into errors):

- run in terminal `docker compose down -v`
- run in terminal `rm terraform.tfstate` (delete the terraform state - makes terraform forget the old ids)
- run `bash ./setup-metabase.sh`
- follow link to create metabase account - use same credentials as previously because previous version of metabase was deleted (use `metabase_admin_email` and `metabase_admin_password` from `terraform.tfvars `)
- run `terraform init`
- run `terraform apply` - run it twice if first time there is error "Unable to find the table given its attributes." as Metabase may be still indexing in the background.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Rolled back the Metabase service to an earlier release (v0.56.19).
  * Updated deployment notes and pinned-version guidance to reflect the reverted Metabase image tag.
  * No user-facing feature changes or behavior differences beyond the image tag update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->