### PR TITLE
MFB-607: Addded scripts to export Metabase dashboards to JSON and generate Terraform HCL 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ venv/
 *.tfstate.*.backup
 terraform.tfvars
 *.tfplan
+
+# dashboards scripts
+dashboards/scripts/generated/
+

--- a/dashboards/scripts/dashboard_generation_helper.md
+++ b/dashboards/scripts/dashboard_generation_helper.md
@@ -1,0 +1,85 @@
+## Metabase Dashboard Generation Helper
+
+This workflow is intended as **reference tool**. While it handles common patterns, specific edge cases or complex visualizations may not be perfectly translated and may require manual adjustments.
+
+This workflow assumes you have already:
+1.  **Modified a Dashboard in the Metabase UI** (e.g., added tabs, moved cards, created new questions).
+2.  **Identified the Dashboard ID**: Grab the number from the end of the URL when viewing that dashboard in your browser (e.g., `.../dashboard/6-north-carolina` -> ID is **6**).
+
+## The 2-Step Workflow
+
+The scripts output temporary reference files. You review these files and manually copy the blocks you need.
+
+### Script 1: Export Dashboard JSON
+**Script:** `export_dashboard_json.py`
+
+This script connects to the Metabase API using credentials from `terraform.tfvars` and downloads the raw JSON definition of a dashboard. **You do NOT need an Anthropic API key to run this**.
+
+**Usage:**
+```bash
+python3 scripts/export_dashboard_json.py <dashboard-id>
+```
+*Example:* `python3 scripts/export_dashboard_json.py 6`
+
+**Output:**
+This will save the JSON to `scripts/generated/dashboard_6.json`.
+
+---
+
+### Script 2: Generate Terraform HCL
+**Script:** `generate_hcl.py`
+
+This script reads a local JSON file generated in Step 1 and uses the Anthropic API (Claude 3) to convert it into Terraform HCL. It requires an `ANTHROPIC_API_KEY` in your `.env` file under `/dashboards`.
+
+**Usage:**
+```bash
+python3 scripts/generate_hcl.py <path-to-json-file>
+```
+*Example:* `python3 scripts/generate_hcl.py scripts/generated/dashboard_6.json`
+
+**Output:**
+This will output a file named `scripts/generated/dashboard_6_hcl.tf.ref`.
+
+The `.tf.ref` extension is intentional! It tricks Terraform into ignoring the file. If we used a standard `.tf` extension, running `terraform init` or `plan` might throw a "Duplicate Resource" error because Terraform loads all `.tf` files in the directory.
+
+---
+
+### Step 3: Review and Copy 
+Open the generated `.tf.ref` file in your editor. Review the code to ensure it follows multi-tenant patterns.
+
+**Where to put the code:**
+1.  **New Cards**: If the script generated new `metabase_card` resources, copy and paste them into your Terraform configuration.
+2.  **Updated Dashboard**: Use the generated `metabase_dashboard` resource to update your existing dashboard configuration. Ensure the `tabs_json` and `cards_json` line up with the new cards you just added.
+
+## Why We Use Example Patterns in the Prompt
+Inside `generate_hcl.py`, you will see a detailed prompt containing an example HCL pattern. These specific details helped fix several critical errors encountered during development, though they serve primarily as a starting point:
+
+1.  **Metabase Provider Quirks**: The `flovouin/metabase` provider requires wrapping card settings in a `jsonencode()` block.
+2.  **Inconsistent Results Error**: Upon creating a card or dashboard, Metabase automatically populates fields (like `cache_ttl`, `description`). We include these boilerplate fields as defaults in both the **card resources** and the **`cards_json` entries** to satisfy the provider and prevent drift errors.
+3.  **Required vs. Metadata IDs**: 
+    *   KEEP: Numeric `id` (in `tabs_json`) and `dashboard_tab_id` (in `cards_json`). These are REQUIRED to link cards to the correct tabs.
+    *   REMOVE: Strings like `entity_id` (e.g., `axV0Xby...`) or other Metabase-internal tracking fields. These are unnecessary metadata.
+
+
+This script is a reference assistant, not a fully automated solution. It may not handle all specific dashboard configurations or complex visualization settings.
+
+## Technical Details (API Calls)
+
+### 1. Metabase Authentication
+- **Endpoint**: `POST /api/session`
+- **Payload**: `{ "username": "...", "password": "..." }`
+- **Response**: Returns a session `id` used in subsequent headers as `X-Metabase-Session`.
+
+### 2. Dashboard Export
+- **Endpoint**: `GET /api/dashboard/<dashboard-id>`
+- **Header**: `X-Metabase-Session: <sid>`
+- **Response**: Full JSON object of the dashboard, including its tabs and card references. Used as the local input for HCL generation.
+
+### 3. AI Generation (Anthropic)
+- **Endpoint**: `POST https://api.anthropic.com/v1/messages`
+- **Model**: Hardcoded as `claude-3-haiku-20240307` for consistent, fast results.
+- **Payload**: Combines the system prompt, the existing `metabase.tf` for context, and the raw dashboard JSON.
+- **Output**: Cleaned HCL code wrapped in `.tf.ref` for safe manual review.
+
+### Git ignore
+The `scripts/generated/` folder is ignored in `.gitignore`. Do not commit raw API JSON dumps or temporary `.tf.ref` files.

--- a/dashboards/scripts/export_dashboard_json.py
+++ b/dashboards/scripts/export_dashboard_json.py
@@ -1,0 +1,134 @@
+import os
+import json
+import http.client
+import sys
+import argparse
+
+def load_tfvars():
+    """Parse terraform.tfvars for Metabase credentials."""
+    tfvars_path = os.path.join(os.path.dirname(__file__), "..", "terraform.tfvars")
+    if not os.path.exists(tfvars_path):
+        print(f"Error: terraform.tfvars not found at {tfvars_path}.")
+        return None
+    
+    creds = {}
+    with open(tfvars_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" in line:
+                key, val = line.split("=", 1)
+                val = val.split("#")[0].strip()
+                creds[key.strip()] = val.strip().strip('"').strip("'")
+    return creds
+
+def get_metabase_session(url, email, password):
+    """Authenticate with Metabase and return session ID."""
+    from urllib.parse import urlparse
+    parsed_url = urlparse(url)
+    host = parsed_url.netloc
+    path_prefix = parsed_url.path.rstrip('/')
+    
+    conn = http.client.HTTPSConnection(host) if parsed_url.scheme == "https" else http.client.HTTPConnection(host)
+    payload = json.dumps({"username": email, "password": password})
+    headers = {"Content-Type": "application/json"}
+    
+    try:
+        conn.request("POST", f"{path_prefix}/api/session", payload, headers)
+        res = conn.getresponse()
+        data = res.read()
+        
+        if res.status != 200:
+            print(f"Metabase Login Error ({res.status}): {data.decode('utf-8')}")
+            return None
+            
+        try:
+            return json.loads(data.decode('utf-8'))['id']
+        except json.JSONDecodeError:
+            print(f"Fatal: Metabase returned non-JSON response: {data.decode('utf-8')}")
+            return None
+    except Exception as e:
+        print(f"Metabase Connection Error: {e}")
+        return None
+    finally:
+        conn.close()
+
+def fetch_metabase_dashboard(url, session_id, dashboard_id):
+    """Fetch dashboard JSON from Metabase."""
+    from urllib.parse import urlparse
+    parsed_url = urlparse(url)
+    host = parsed_url.netloc
+    path_prefix = parsed_url.path.rstrip('/')
+    
+    conn = http.client.HTTPSConnection(host) if parsed_url.scheme == "https" else http.client.HTTPConnection(host)
+    headers = {"Content-Type": "application/json", "X-Metabase-Session": session_id}
+    
+    try:
+        conn.request("GET", f"{path_prefix}/api/dashboard/{dashboard_id}", headers=headers)
+        res = conn.getresponse()
+        data = res.read()
+        
+        if res.status != 200:
+            print(f"Metabase Fetch Error ({res.status}): {data.decode('utf-8')}")
+            return None
+            
+        return data.decode('utf-8')
+    except Exception as e:
+        print(f"Metabase Fetch Error: {e}")
+        return None
+    finally:
+        conn.close()
+
+def main():
+    parser = argparse.ArgumentParser(description="Export a Metabase dashboard to a JSON file")
+    parser.add_argument("dashboard_id", help="ID of an existing Metabase dashboard to export")
+    parser.add_argument("--output", "-o", help="Output file name (default: generated/dashboard_<id>.json)")
+    args = parser.parse_args()
+
+    creds = load_tfvars()
+    if not creds:
+        sys.exit(1)
+        
+    url = creds.get('metabase_url')
+    email = creds.get('metabase_admin_email')
+    password = creds.get('metabase_admin_password')
+    
+    if not all([url, email, password]):
+        print("Error: credentials missing in terraform.tfvars")
+        sys.exit(1)
+        
+    print(f"Connecting to Metabase...")
+    session_id = get_metabase_session(url, email, password)
+    if not session_id:
+        sys.exit(1)
+        
+    print(f"Fetching dashboard {args.dashboard_id}...")
+    json_content = fetch_metabase_dashboard(url, session_id, args.dashboard_id)
+    if not json_content:
+        sys.exit(1)
+
+    # Setup output path
+    output_dir = os.path.join(os.path.dirname(__file__), "generated")
+    os.makedirs(output_dir, exist_ok=True)
+    
+    output_file = args.output
+    if not output_file:
+        output_file = os.path.join(output_dir, f"dashboard_{args.dashboard_id}.json")
+    else:
+        # If user provides a path, ensure we can write to it
+        os.makedirs(os.path.dirname(os.path.abspath(output_file)) or '.', exist_ok=True)
+
+    with open(output_file, "w") as f:
+        # Format the JSON nicely before saving
+        try:
+            parsed_json = json.loads(json_content)
+            json.dump(parsed_json, f, indent=2)
+        except:
+            f.write(json_content)
+
+    print(f"\nSuccess! Dashboard JSON saved to {output_file}")
+    print(f"You can now run generate_hcl.py to convert this into Terraform HCL.")
+
+if __name__ == "__main__":
+    main()

--- a/dashboards/scripts/export_dashboard_json.py
+++ b/dashboards/scripts/export_dashboard_json.py
@@ -3,6 +3,8 @@ import json
 import http.client
 import sys
 import argparse
+from urllib.parse import urlparse
+import re
 
 def load_tfvars():
     """Parse terraform.tfvars for Metabase credentials."""
@@ -19,13 +21,12 @@ def load_tfvars():
                 continue
             if "=" in line:
                 key, val = line.split("=", 1)
-                val = val.split("#")[0].strip()
+                val = re.split(r'\s+#', val, maxsplit=1)[0].strip()
                 creds[key.strip()] = val.strip().strip('"').strip("'")
     return creds
 
 def get_metabase_session(url, email, password):
     """Authenticate with Metabase and return session ID."""
-    from urllib.parse import urlparse
     parsed_url = urlparse(url)
     host = parsed_url.netloc
     path_prefix = parsed_url.path.rstrip('/')
@@ -56,7 +57,6 @@ def get_metabase_session(url, email, password):
 
 def fetch_metabase_dashboard(url, session_id, dashboard_id):
     """Fetch dashboard JSON from Metabase."""
-    from urllib.parse import urlparse
     parsed_url = urlparse(url)
     host = parsed_url.netloc
     path_prefix = parsed_url.path.rstrip('/')
@@ -98,7 +98,7 @@ def main():
         print("Error: credentials missing in terraform.tfvars")
         sys.exit(1)
         
-    print(f"Connecting to Metabase...")
+    print("Connecting to Metabase...")
     session_id = get_metabase_session(url, email, password)
     if not session_id:
         sys.exit(1)
@@ -124,11 +124,11 @@ def main():
         try:
             parsed_json = json.loads(json_content)
             json.dump(parsed_json, f, indent=2)
-        except:
+        except json.JSONDecodeError:
             f.write(json_content)
 
     print(f"\nSuccess! Dashboard JSON saved to {output_file}")
-    print(f"You can now run generate_hcl.py to convert this into Terraform HCL.")
+    print("You can now run generate_hcl.py to convert this into Terraform HCL.")
 
 if __name__ == "__main__":
     main()

--- a/dashboards/scripts/generate_hcl.py
+++ b/dashboards/scripts/generate_hcl.py
@@ -1,0 +1,195 @@
+import os
+import json
+import http.client
+import sys
+import argparse
+
+# --- Constants ---
+ANTHROPIC_HOST = "api.anthropic.com"
+ANTHROPIC_PATH = "/v1/messages"
+ANTHROPIC_VERSION = "2023-06-01"
+
+def load_env():
+    """Load ANTHROPIC_API_KEY from .env file synchronously."""
+    env_path = os.path.join(os.path.dirname(__file__), "..", ".env")
+    if not os.path.exists(env_path):
+        print(f"Error: .env file not found at {env_path}")
+        sys.exit(1)
+    
+    with open(env_path, "r") as f:
+        for line in f:
+            if line.startswith("ANTHROPIC_API_KEY="):
+                return line.strip().split("=")[1]
+    
+    print("Error: ANTHROPIC_API_KEY not found in .env")
+    sys.exit(1)
+
+def call_anthropic_api(api_key, system_prompt, user_prompt, model="claude-3-haiku-20240307"):
+    """Call the Claude API using standard http.client."""
+    conn = http.client.HTTPSConnection(ANTHROPIC_HOST)
+    
+    payload = json.dumps({
+        "model": model,
+        "max_tokens": 4096,
+        "system": system_prompt,
+        "messages": [
+            {"role": "user", "content": user_prompt}
+        ]
+    })
+    
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": ANTHROPIC_VERSION,
+        "content-type": "application/json"
+    }
+    
+    try:
+        conn.request("POST", ANTHROPIC_PATH, payload, headers)
+        res = conn.getresponse()
+        data = res.read()
+        
+        if res.status != 200:
+            error_text = data.decode('utf-8')
+            print("\n" + "!"*60)
+            print(f"ANTHROPIC API ERROR ({res.status})")
+            if "overloaded" in error_text.lower():
+                print("The model is currently overloaded. Please wait a minute and try again.")
+            elif "rate_limit" in error_text.lower() or "credit_balance" in error_text.lower():
+                print("You may have hit a Rate Limit or have insufficient credits.")
+                print("Please check your Anthropic dashboard.")
+            else:
+                print(f"Error details: {error_text}")
+            print("!"*60 + "\n")
+            sys.exit(1)
+            
+        response_json = json.loads(data.decode('utf-8'))
+        return response_json['content'][0]['text']
+    except Exception as e:
+        print(f"\nConnection Error: {e}")
+        print("Please check your internet connection and ANTHROPIC_API_KEY.\n")
+        sys.exit(1)
+    finally:
+        conn.close()
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate Metabase Terraform code using AI from a JSON file")
+    parser.add_argument("input_json", help="Path to the exported Metabase JSON file (e.g., generated/dashboard_6.json)")
+    parser.add_argument("--output", "-o", help="Output file name (default: generated/dashboard_<name>_hcl.tf.ref)")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.input_json):
+        print(f"Error: Could not find input file at {args.input_json}")
+        sys.exit(1)
+
+    with open(args.input_json, "r") as f:
+        json_content = f.read()
+
+    api_key = load_env()
+    
+    # Load reference from metabase.tf for context
+    tf_path = os.path.join(os.path.dirname(__file__), "..", "metabase.tf")
+    reference_code = ""
+    if os.path.exists(tf_path):
+        with open(tf_path, "r") as f:
+            reference_code = f.read()
+
+    system_prompt = f"""You are a Terraform expert specialized in the 'flovouin/metabase' provider.
+Your task is to convert Metabase dashboard JSON into Terraform HCL.
+
+CRITICAL RULES:
+1. Portability Rule: Do NOT use MBQL/GUI queries with field IDs. Convert all cards to Native SQL queries using column names (e.g., SELECT ... FROM analytics.table).
+2. Tab Mapping Rule: Map dashboard cards to the correct `dashboard_tab_id` using the ID defined in the `tabs_json` block of the existing `metabase_dashboard.tenant_analytics` resource.
+3. Pattern Rule: Use `for_each = var.tenants` and reference resources using `[each.key]`.
+4. HCL Structure: The 'flovouin/metabase' provider requires `json = jsonencode({{ ... }})` for `metabase_card`.
+5. Consistency Rule: To avoid "inconsistent result" errors, you MUST include ALL boilerplate fields in the JSON (description, cache_ttl, parameters, etc.) even if they are null.
+6. Dashboard Cards: The `cards_json` attribute in `metabase_dashboard` MUST be a list of objects containing `card_id = tonumber(metabase_card.NAME[each.key].id)`. You MUST also include `parameter_mappings = []`, `series = []`, and `visualization_settings = {{}}` for each card entry.
+7. Multi-Tenant Branding: Dashboard and Card names MUST use dynamic interpolation. For example, use `name = "${{each.value.display_name}} Dashboard"` instead of hardcoded names like "North Carolina Dashboard".
+
+NEGATIVE CONSTRAINTS (DO NOT DO THESE):
+1. NO API DUMPING: Do NOT copy raw fields from the Metabase API response (like `lib_breakout?`, `entity_id`, `enable_embedding`, `parameters`, `auto_apply_filters`, `can_write`, `archived`, etc.) into the HCL. These are either invalid HCL identifiers or unsupported by the Terraform provider.
+2. NO EMBEDDED CARDS: Do NOT include a `card = {{ ... }}` block inside `cards_json`. Only provide the `card_id`, `row`, `col`, `size_x`, `size_y`, and `dashboard_tab_id`.
+3. NO RAW IDS: Never use raw integer IDs for cards (e.g., `card_id = 93`) or fields (e.g., `["field", 1421, ...]`).
+    *   **Cards**: Always use `tonumber(metabase_card.NAME[each.key].id)`.
+    *   **Fields**: Always use `tonumber(data.metabase_table.TABLE_NAME[each.key].fields["COLUMN_NAME"])`.
+4. NO METADATA OR POSITIONS: In `tabs_json`, DO NOT include `entity_id`, `position`, or other unneeded Metabase metadata. ONLY include `id` and `name`.
+
+EXAMPLE HCL PATTERN:
+```hcl
+resource "metabase_card" "tenant_metric" {{
+  for_each = var.tenants
+  json = jsonencode({{
+    name                = "Metric Name"
+    description         = null
+    collection_id       = tonumber(local.tenant_collection_map[each.key].id)
+    collection_position = null
+    cache_ttl           = null
+    query_type          = "query"
+    dataset_query = {{
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      type     = "query"
+      query = {{
+        source-table = tonumber(data.metabase_table.tenant_screen_summary_tables[each.key].id)
+        aggregation  = [["count"]]
+      }}
+    }}
+    parameter_mappings     = []
+    display                = "scalar"
+    visualization_settings = {{}}
+    parameters             = []
+  }})
+}}
+
+resource "metabase_dashboard" "tenant_analytics" {{
+  for_each = var.tenants
+  ...
+  cards_json = jsonencode([
+    {{
+      card_id          = tonumber(metabase_card.tenant_metric[each.key].id)
+      dashboard_tab_id = 460
+      row              = 0
+      col              = 0
+      size_x           = 6
+      size_y           = 4
+      parameter_mappings = []
+      series           = []
+      visualization_settings = {{}}
+    }}
+  ])
+}}
+```
+
+EXISTING CODE FOR CONTEXT:
+{reference_code[:4000]} 
+"""
+
+    user_prompt = f"""Convert this Metabase dashboard JSON into a TEMPLATIZED Terraform resource named "tenant_analytics" that uses for_each = var.tenants.
+Ensure it looks exactly like the existing "tenant_analytics" dashboard but updated with the new tabs/cards from this JSON.
+
+JSON DATA:
+{json_content}
+"""
+    print(f"Generating Terraform HCL...")
+    generated_code = call_anthropic_api(api_key, system_prompt, user_prompt)
+    
+    # Extraction logic
+    if "```hcl" in generated_code:
+        generated_code = generated_code.split("```hcl")[1].split("```")[0].strip()
+    elif "```" in generated_code:
+        generated_code = generated_code.split("```")[1].split("```")[0].strip()
+
+    # Determine output path
+    output_file = args.output
+    if not output_file:
+        base_name = os.path.basename(args.input_json).replace(".json", "")
+        output_dir = os.path.dirname(args.input_json)
+        output_file = os.path.join(output_dir, f"{base_name}_hcl.tf.ref")
+        
+    print(f"Writing generated HCL to {output_file}...")
+    with open(output_file, "w") as f:
+        f.write(generated_code)
+        
+    print(f"\nSuccess! Code saved to {output_file}")
+    print(f"You can now review the file and manually copy the blocks you want into metabase.tf.")
+
+if __name__ == "__main__":
+    main()

--- a/dashboards/scripts/generate_hcl.py
+++ b/dashboards/scripts/generate_hcl.py
@@ -19,7 +19,7 @@ def load_env():
     with open(env_path, "r") as f:
         for line in f:
             if line.startswith("ANTHROPIC_API_KEY="):
-                return line.strip().split("=")[1]
+                return line.strip().split("=", 1)[1]
     
     print("Error: ANTHROPIC_API_KEY not found in .env")
     sys.exit(1)
@@ -93,6 +93,21 @@ def main():
         with open(tf_path, "r") as f:
             reference_code = f.read()
 
+    # Truncate reference code safely to avoid cutting mid-resource
+    def trim_to_resource_boundary(text, limit):
+        if len(text) <= limit:
+            return text
+        trimmed = text[:limit]
+
+        last_boundary = -1
+        for marker in ["\nresource ", "\nmodule ", "\nlocals ", "\nvariable ", "\ndata ", "\nprovider "]:
+            pos = trimmed.rfind(marker)
+            if pos > last_boundary:
+                last_boundary = pos
+        if last_boundary != -1:
+            return text[:last_boundary] + "\n# ... [truncated]"
+        return trimmed + "\n# ... [truncated]"
+
     system_prompt = f"""You are a Terraform expert specialized in the 'flovouin/metabase' provider.
 Your task is to convert Metabase dashboard JSON into Terraform HCL.
 
@@ -159,7 +174,7 @@ resource "metabase_dashboard" "tenant_analytics" {{
 ```
 
 EXISTING CODE FOR CONTEXT:
-{reference_code[:4000]} 
+{trim_to_resource_boundary(reference_code, 4000)}
 """
 
     user_prompt = f"""Convert this Metabase dashboard JSON into a TEMPLATIZED Terraform resource named "tenant_analytics" that uses for_each = var.tenants.
@@ -168,7 +183,7 @@ Ensure it looks exactly like the existing "tenant_analytics" dashboard but updat
 JSON DATA:
 {json_content}
 """
-    print(f"Generating Terraform HCL...")
+    print("Generating Terraform HCL...")
     generated_code = call_anthropic_api(api_key, system_prompt, user_prompt)
     
     # Extraction logic
@@ -176,6 +191,8 @@ JSON DATA:
         generated_code = generated_code.split("```hcl")[1].split("```")[0].strip()
     elif "```" in generated_code:
         generated_code = generated_code.split("```")[1].split("```")[0].strip()
+    else:
+        print("Warning: No code blocks found in response. Output may contain explanatory text.")
 
     # Determine output path
     output_file = args.output
@@ -189,7 +206,7 @@ JSON DATA:
         f.write(generated_code)
         
     print(f"\nSuccess! Code saved to {output_file}")
-    print(f"You can now review the file and manually copy the blocks you want into metabase.tf.")
+    print("You can now review the file and manually copy the blocks you want into metabase.tf.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

Fixes: #[MFB-607](https://linear.app/myfriendben/issue/MFB-607/data-white-label-dashboard-benefits-and-immediate-needs-page)

This PR adds helper scripts and documentation to assist with converting Metabase dashboards into multi-tenant Terraform configuration. These are intended as reference tools to simplify the manual overhead of translating UI changes into HCL.

## Changes
Included Tools:
- Script 1: Export Dashboard JSON (export_dashboard_json.py).
Once a user makes changes in the Metabase UI, this script is run to download the raw JSON configuration of that dashboard.

- Script 2: Generate Terraform HCL (generate_hcl.py).
Once you have the JSON, you can run this script to transform it into HCL. As some dashboards can be complex, this script may not handle all use cases. It creates a new .tf.ref file where the code can be reviewed and copy-pasted (or adjusted manually based on the specific case).
This script requirs `ANTHROPIC_API_KEY` in your `.env` file under `/dashboards`.

Details are included in **dashboard_generation_helper.md**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export Metabase dashboards to JSON
  * Convert exported dashboards into Terraform HCL via an assisted generation workflow

* **Documentation**
  * Added a comprehensive guide describing the two-step dashboard generation and manual review steps

* **Chores**
  * Updated ignore rules to exclude generated dashboard artifacts from source control
<!-- end of auto-generated comment: release notes by coderabbit.ai -->