### PR TITLE
Add dbt nightly GitHub Actions workflow for Heroku Postgres

### DIFF
--- a/.github/workflows/dbt-nightly.yml
+++ b/.github/workflows/dbt-nightly.yml
@@ -37,6 +37,7 @@ jobs:
       DB_PASS: ${{ secrets.GLOBAL_DB_PASS }}
       DB_NAME: ${{ vars.DATABASE_NAME }}
       DB_SSLMODE: require
+      PGSSLMODE: require
       DB_SCHEMA: analytics
     steps:
       - uses: actions/checkout@v4
@@ -67,8 +68,7 @@ jobs:
             -h "$DB_HOST" \
             -U "$DB_USER" \
             -d "$DB_NAME" \
-            -c "CREATE SCHEMA IF NOT EXISTS analytics;" \
-            "sslmode=require"
+            -c "CREATE SCHEMA IF NOT EXISTS analytics;"
 
       - name: Run dbt build
         run: |

--- a/.github/workflows/dbt-nightly.yml
+++ b/.github/workflows/dbt-nightly.yml
@@ -1,0 +1,89 @@
+name: dbt Nightly Build
+
+on:
+  schedule:
+    # Run daily at 6 AM UTC (1 AM EST / 10 PM PST)
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      full_refresh:
+        description: "Run dbt build with --full-refresh"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  dbt-build:
+    # Production runs only allowed from main branch
+    if: >-
+      github.event_name != 'workflow_dispatch'
+      || github.event.inputs.environment != 'production'
+      || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'staging' }}
+    defaults:
+      run:
+        working-directory: dbt
+    env:
+      DB_HOST: ${{ secrets.DATABASE_HOST }}
+      DB_USER: ${{ secrets.GLOBAL_DB_USER }}
+      DB_PASS: ${{ secrets.GLOBAL_DB_PASS }}
+      DB_NAME: ${{ vars.DATABASE_NAME }}
+      DB_SSLMODE: require
+      DB_SCHEMA: analytics
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: dbt/requirements.txt
+
+      - name: Install dbt dependencies
+        run: pip install -r requirements.txt
+
+      - name: Configure dbt profile
+        run: |
+          mkdir -p ~/.dbt
+          cp profiles.yml.example ~/.dbt/profiles.yml
+
+      - name: Install dbt packages
+        run: dbt deps
+
+      - name: Verify dbt connection
+        run: dbt debug
+
+      - name: Ensure analytics schema exists
+        run: |
+          PGPASSWORD="$DB_PASS" psql \
+            -h "$DB_HOST" \
+            -U "$DB_USER" \
+            -d "$DB_NAME" \
+            -c "CREATE SCHEMA IF NOT EXISTS analytics;" \
+            "sslmode=require"
+
+      - name: Run dbt build
+        run: |
+          FLAGS="--target postgres"
+          if [ "${{ github.event.inputs.full_refresh }}" = "true" ]; then
+            FLAGS="$FLAGS --full-refresh"
+          fi
+          dbt build $FLAGS
+
+      - name: Upload dbt artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dbt-artifacts
+          path: |
+            dbt/target/manifest.json
+            dbt/target/run_results.json
+          retention-days: 7

--- a/dashboards/GITHUB_SECRETS.md
+++ b/dashboards/GITHUB_SECRETS.md
@@ -176,6 +176,23 @@ Use these separate credentials for `GLOBAL_DB_*`, `NC_DB_*`, and `CO_DB_*` secre
 
 ---
 
+## dbt Nightly Workflow
+
+The `dbt-nightly.yml` workflow reuses the same staging environment secrets as Terraform — no new secrets are needed:
+
+| dbt env var | GitHub secret/variable |
+|-------------|----------------------|
+| `DB_HOST` | `DATABASE_HOST` (secret) |
+| `DB_USER` | `GLOBAL_DB_USER` (secret) |
+| `DB_PASS` | `GLOBAL_DB_PASS` (secret) |
+| `DB_NAME` | `DATABASE_NAME` (variable) |
+| `DB_SSLMODE` | Hardcoded to `require` |
+| `DB_SCHEMA` | Hardcoded to `analytics` |
+
+The workflow runs nightly at 6 AM UTC against staging. Production runs require manual dispatch from the `main` branch.
+
+---
+
 ## Prerequisite: Analytics Schema
 
 Ensure the `analytics` schema exists in both staging and production databases:

--- a/dbt/profiles.yml.example
+++ b/dbt/profiles.yml.example
@@ -9,6 +9,7 @@ benefits:
       port: "{{ env_var('DB_PORT', 5432) }}"
       dbname: "{{ env_var('DB_NAME') }}"
       schema: "{{ env_var('DB_SCHEMA', 'analytics') }}"
+      sslmode: "{{ env_var('DB_SSLMODE', 'prefer') }}"
       threads: 4
       connect_timeout: 30
 


### PR DESCRIPTION
Unblocks Terraform apply by populating the analytics schema that Metabase table lookups depend on. The workflow runs dbt from a GitHub Actions runner directly against Heroku Postgres — no deployment or Heroku scheduler needed.

- Add .github/workflows/dbt-nightly.yml (cron 6AM UTC + manual dispatch)
- Add sslmode to dbt/profiles.yml.example for Heroku SSL requirement
- Document secret reuse in dashboards/GITHUB_SECRETS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated nightly dbt build workflow that runs daily at 6:00 AM UTC with support for manual dispatch with custom environment and refresh options.

* **Documentation**
  * Added setup documentation for the dbt Nightly Workflow, including GitHub secrets mapping and scheduling details.

* **Chores**
  * Enhanced database profile configuration with SSL mode support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->