### PR TITLE
Add Metabase schema sync step to dbt-nightly workflow

### DIFF
--- a/.github/workflows/dbt-nightly.yml
+++ b/.github/workflows/dbt-nightly.yml
@@ -78,6 +78,40 @@ jobs:
           fi
           dbt build $FLAGS
 
+      - name: Trigger Metabase schema sync
+        run: |
+          METABASE_API="${METABASE_URL}/api"
+
+          # Get session token
+          SESSION=$(curl -sf -X POST "${METABASE_API}/session" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\": \"${METABASE_ADMIN_EMAIL}\", \"password\": \"${METABASE_ADMIN_PASSWORD}\"}" \
+            | jq -r '.id')
+
+          if [ -z "$SESSION" ] || [ "$SESSION" = "null" ]; then
+            echo "::warning::Failed to authenticate with Metabase — skipping sync"
+            exit 0
+          fi
+
+          # Get all database IDs and trigger sync on each
+          DB_IDS=$(curl -sf "${METABASE_API}/database" \
+            -H "X-Metabase-Session: ${SESSION}" \
+            | jq -r '.data[].id')
+
+          for DB_ID in $DB_IDS; do
+            echo "Syncing database ${DB_ID}..."
+            curl -sf -X POST "${METABASE_API}/database/${DB_ID}/sync_schema" \
+              -H "X-Metabase-Session: ${SESSION}"
+          done
+
+          echo "Waiting 30s for Metabase to complete sync..."
+          sleep 30
+          echo "Sync triggered for all databases."
+        env:
+          METABASE_URL: ${{ vars.METABASE_URL }}
+          METABASE_ADMIN_EMAIL: ${{ vars.METABASE_ADMIN_EMAIL }}
+          METABASE_ADMIN_PASSWORD: ${{ secrets.METABASE_ADMIN_PASSWORD }}
+
       - name: Upload dbt artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/dbt-nightly.yml
+++ b/.github/workflows/dbt-nightly.yml
@@ -94,14 +94,21 @@ jobs:
           fi
 
           # Get all database IDs and trigger sync on each
-          DB_IDS=$(curl -sf "${METABASE_API}/database" \
+          DB_IDS=$(curl -s "${METABASE_API}/database" \
             -H "X-Metabase-Session: ${SESSION}" \
             | jq -r '.data[].id')
 
+          if [ -z "$DB_IDS" ]; then
+            echo "::warning::No databases found or failed to fetch database list — skipping sync"
+            exit 0
+          fi
+
           for DB_ID in $DB_IDS; do
             echo "Syncing database ${DB_ID}..."
-            curl -sf -X POST "${METABASE_API}/database/${DB_ID}/sync_schema" \
-              -H "X-Metabase-Session: ${SESSION}"
+            if ! curl -sf -X POST "${METABASE_API}/database/${DB_ID}/sync_schema" \
+              -H "X-Metabase-Session: ${SESSION}"; then
+              echo "::warning::Failed to sync database ${DB_ID}"
+            fi
           done
 
           echo "Waiting 30s for Metabase to complete sync..."


### PR DESCRIPTION
After dbt build completes, trigger sync_schema on all Metabase databases so Terraform can find the newly created tables without a manual sync. Uses existing Metabase admin credentials from the GitHub environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Nightly workflows now trigger a schema synchronization for the reporting system to keep metadata current after builds.
  * The process includes authentication, per-database sync triggering, a short wait for completion, and completion logging.
  * Added error handling to emit warnings and skip sync when authentication fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->