### PR TITLE
Add config template and resusable number format presets

### DIFF
--- a/dashboards/config_template.tf
+++ b/dashboards/config_template.tf
@@ -69,6 +69,6 @@ locals {
   } 
 
   show_minibar_true = {
-    "show_mini_bar" = "true"
+    "show_mini_bar" = true
   }
 }

--- a/dashboards/config_template.tf
+++ b/dashboards/config_template.tf
@@ -1,0 +1,74 @@
+# Shared configuration template for screen count cards
+locals {
+  screen_count_card_config = {
+    name                = "Completed Screens"
+    description         = "Total count of completed screens from PostgreSQL"
+    collection_position = null
+    cache_ttl           = null
+    query_type          = "query"
+    dataset_query = {
+      query = {
+        aggregation = [
+          ["count"]
+        ]
+      }
+      type = "query"
+    }
+    parameter_mappings     = []
+    display                = "scalar"
+    visualization_settings = {}
+    parameters             = []
+  }
+
+  # Shared templates for tenant cards (reusable across all dashboard tabs)
+  tenant_card_base_config = {
+    description         = null
+    collection_position = null
+    cache_ttl           = null
+    query_type          = "native"
+    dataset_query = {
+      type = "native"
+    }
+    parameter_mappings     = []
+    parameters             = []
+    visualization_settings = {}
+  }
+  
+  # Template for scalar scorecards (simple counts)
+  tenant_scorecard_config = merge(local.tenant_card_base_config, {
+    display = "scalar"
+  })
+
+  # Template for percentage cards
+  tenant_percentage_card_config = merge(local.tenant_scorecard_config, {
+    visualization_settings = {
+      "column_settings" = {}
+    }
+  })
+  
+  # Template for table cards with mini bars (flexible)
+  tenant_table_card_config = merge(local.tenant_card_base_config, {
+    display = "table"
+    visualization_settings = {
+      "table.column_widths" = []
+      "column_settings" = {}
+    }
+  })
+
+  # Reusable number and format presets
+  number_format_percent_0 = {
+    "number_style" = "percent"
+    "decimals"     = 0
+  }
+
+  currency_format_0 = { 
+    "number_style" = "currency"
+    "currency" = "USD"
+    "currency_style" = "symbol"
+    "decimals" = 0 
+  } 
+
+  show_minibar_true = {
+    "show_mini_bar" = "true"
+  }
+}

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -293,8 +293,18 @@ resource "metabase_dashboard" "tenant_analytics" {
     { id = 5, name = "Benefits & Immediate Needs" }
   ])
 
-  cards_json = jsonencode(concat(
-    # Tab 5: Benefits & Immediate Needs
-    local.tenant_tab_5_benefits_needs_layout[each.key]
-  ))
+  cards_json = jsonencode([
+    {
+      card_id = tonumber(metabase_card.tenant_screen_count[each.key].id)
+      # Assigning existing card to "All-Time Performance" tab (ID 2)
+      dashboard_tab_id       = 2
+      row                    = 0
+      col                    = 0
+      size_x                 = 6
+      size_y                 = 4
+      parameter_mappings     = []
+      series                 = []
+      visualization_settings = {}
+    }
+  ])
 }

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -5,29 +5,6 @@ provider "metabase" {
   password = var.metabase_admin_password
 }
 
-# Shared configuration template for screen count cards
-locals {
-  screen_count_card_config = {
-    name                = "Completed Screens"
-    description         = "Total count of completed screens from PostgreSQL"
-    collection_position = null
-    cache_ttl           = null
-    query_type          = "query"
-    dataset_query = {
-      query = {
-        aggregation = [
-          ["count"]
-        ]
-      }
-      type = "query"
-    }
-    parameter_mappings     = []
-    display                = "scalar"
-    visualization_settings = {}
-    parameters             = []
-  }
-}
-
 resource "metabase_database" "bigquery" {
   name = "MFB BigQuery Analytics"
   bigquery_details = {
@@ -306,18 +283,8 @@ resource "metabase_dashboard" "tenant_analytics" {
     { id = 5, name = "Benefits & Immediate Needs" }
   ])
 
-  cards_json = jsonencode([
-    {
-      card_id = tonumber(metabase_card.tenant_screen_count[each.key].id)
-      # Assigning existing card to "All-Time Performance" tab (ID 2)
-      dashboard_tab_id       = 2
-      row                    = 0
-      col                    = 0
-      size_x                 = 6
-      size_y                 = 4
-      parameter_mappings     = []
-      series                 = []
-      visualization_settings = {}
-    }
-  ])
+  cards_json = jsonencode(concat(
+    # Tab 5: Benefits & Immediate Needs
+    local.tenant_tab_5_benefits_needs_layout[each.key]
+  ))
 }


### PR DESCRIPTION
This PR introduces `config_template.tf` to define reusable Metabase card configuration templates. The goal is to reduce duplicated Terraform code, keep card definitions cleaner, and minimize configuration mistakes.

The approach is to define a base config and extend it for commonly used card types.

**Template**
`config_template.tf` defines a base card configuration:

```
tenant_card_base_config = {
    description         = null
    collection_position = null
    cache_ttl           = null
    query_type          = "native"
    dataset_query = {
      type = "native"
    }
    parameter_mappings     = []
    parameters             = []
    visualization_settings = {}
  }
```

Since different cards require different display types (e.g., counts, percentages, currency), we extend this base configuration to create more specialized templates.

Example templates:
```
  tenant_scorecard_config = merge(local.tenant_card_base_config, {
    display = "scalar"
  })

  # Template for percentage cards
  tenant_percentage_card_config = merge(local.tenant_scorecard_config, {
    visualization_settings = {
      "column_settings" = {}
    }
  })

  # Template for table cards with mini bars (flexible)
  tenant_table_card_config = merge(local.tenant_card_base_config, {
    display = "table"
    visualization_settings = {
      "table.column_widths" = []
      "column_settings" = {}
    }
  })
```

**Usage**
When defining a card resource, instead of repeating all configuration fields, we can extend one of the templates and only specify the fields that differ.

```
resource "metabase_card" "tenant_example_table" {
  for_each = var.tenants
  json = jsonencode(merge(local.tenant_table_card_config, {
    name                = "Provide name here as usual"
    collection_id       = tonumber(local.tenant_collection_map[each.key].id)
    visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
      "table.column_widths" = [{ "name" = "Name", "width" = 300 }]
      "column_settings" = local.benefits_column_settings
    })
    dataset_query = {
      type     = "native"
      database = tonumber(metabase_database.tenant_postgres[each.key].id)
      native = {query = "..."}
  }
  }))
}
```

**Formatting Helpers**
`config_template.tf` also defines commonly used formatting helpers, such as:
  - number_format_percent_0
  - currency_format_0
  - show_minibar_true


These can be referenced directly via `local.*`. When combining them with other settings, use `merge()` to ensure the configuration is applied correctly.

***Example***:
`local.number_format_percent_0`

**Dashboard-Level Shared Settings**
Within a dashboard configuration, we can also define reusable settings for frequently used column configurations.

***Example***:
```
benefits_column_settings = {
    "[\"name\",\"# of Screeners\"]" = merge(
      local.show_minibar_true,
      { "color" = "#293458" }
    )

    "[\"name\",\"% of Screeners\"]" = merge(
      local.show_minibar_true,
      local.number_format_percent_0,
      { "color" = "#DF7F44" }
    )

    "[\"name\",\"pct\"]" = merge(
      local.number_format_percent_0,
      { "color" = "#DF7F44" }
    )
  }
```
This pattern helps keep dashboard configurations concise and consistent. Feel free to add more reusable configs as we continue working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable dashboard card templates and display/formatting presets for count, scorecard, percentage, and table cards to standardize visuals and behavior.

* **Refactor**
  * Removed the prior centralized screen-count template and shifted to per-tenant, inline configurations—enabling flexible tenant-specific dashboard card layouts and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->