### PR TITLE
feat(terraform): support local state override for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ venv/
 *.tfstate.backup
 *.tfstate.*.backup
 terraform.tfvars
+local_override.tf
 *.tfplan
 
 # dashboards scripts

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -187,13 +187,14 @@ backend using a gitignored override file.
 cp local_override.tf.example local_override.tf
 ```
 
-**2. Run Terraform normally:**
+**2. Initialize Terraform:**
 
 ```bash
 terraform init    # uses local state, no Terraform Cloud token needed
-terraform plan
-terraform apply
 ```
+
+`terraform plan` and `terraform apply` require a locally running Metabase
+instance — see the Quick Start section above for that setup.
 
 `local_override.tf` is gitignored — CI/CD never sees it, so GitHub Actions
 continues using Terraform Cloud for staging and production.

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -175,6 +175,29 @@ terraform plan  # Review changes
 terraform apply  # Deploy new configuration
 ```
 
+## Local Terraform State for Development
+
+Production uses Terraform Cloud for state (configured in `main.tf`). Running
+`terraform init` locally will fail with a token error unless you override the
+backend using a gitignored override file.
+
+**1. Copy the example override file:**
+
+```bash
+cp local_override.tf.example local_override.tf
+```
+
+**2. Run Terraform normally:**
+
+```bash
+terraform init    # uses local state, no Terraform Cloud token needed
+terraform plan
+terraform apply
+```
+
+`local_override.tf` is gitignored — CI/CD never sees it, so GitHub Actions
+continues using Terraform Cloud for staging and production.
+
 ## Troubleshooting
 
 ### Dashboard shows "No data"
@@ -196,3 +219,4 @@ terraform destroy
 git checkout <other-branch>
 terraform apply
 ```
+

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -177,7 +177,7 @@ terraform apply  # Deploy new configuration
 
 ## Local Terraform State for Development
 
-Production uses Terraform Cloud for state (configured in `main.tf`). Running
+CI/CD uses Terraform Cloud for state (configured in `main.tf`). Running
 `terraform init` locally will fail with a token error unless you override the
 backend using a gitignored override file.
 

--- a/dashboards/local_override.tf.example
+++ b/dashboards/local_override.tf.example
@@ -1,0 +1,15 @@
+# local_override.tf.example
+#
+# This file shows how to override the Terraform Cloud backend
+# for local development.
+#
+# Usage:
+#   cp local_override.tf.example local_override.tf
+#
+# local_override.tf is gitignored - it only exists on your machine.
+# CI/CD (GitHub Actions) does NOT have this file, so it continues
+# using Terraform Cloud for staging and production.
+
+terraform {
+  backend "local" {}
+}

--- a/dashboards/local_override.tf.example
+++ b/dashboards/local_override.tf.example
@@ -1,14 +1,6 @@
-# local_override.tf.example
-#
-# This file shows how to override the Terraform Cloud backend
-# for local development.
-#
-# Usage:
-#   cp local_override.tf.example local_override.tf
-#
-# local_override.tf is gitignored - it only exists on your machine.
-# CI/CD (GitHub Actions) does NOT have this file, so it continues
-# using Terraform Cloud for staging and production.
+# Overrides the Terraform Cloud backend with local state for development.
+# Usage: cp local_override.tf.example local_override.tf
+# This file is gitignored — CI/CD continues using Terraform Cloud.
 
 terraform {
   backend "local" {}


### PR DESCRIPTION
## Context & Motivation:

**Fixed**: [MFB-802](https://linear.app/myfriendben/issue/MFB-802/data-support-for-local-terraform-state-during-development)
**Related PR:** None

**Problem**: After Terraform Cloud was configured in main.tf, running terraform init locally fails with Error: Required token could not be found. Developers should not need a Terraform Cloud account to work locally.

**Solution**: Add a gitignored local_override.tf that overrides the cloud {} block with backend "local" {}. CI/CD never has this file, so GitHub Actions continues using Terraform Cloud for staging and production unchanged.

To use locally:


`cp local_override.tf.example local_override.tf`
`terraform init ` # works without Terraform Cloud token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using a local Terraform state for development, including a sample override configuration, workflow steps, troubleshooting tips for database user/identifiers, and notes on safely switching branches (destroy/re-apply).

* **Chores**
  * Updated ignore patterns to exclude local Terraform override files from version control so local development overrides are not committed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->