### PR TITLE
Fix dbt BigQuery auth to use oauth for WIF

### DIFF
--- a/dbt/profiles.yml.example
+++ b/dbt/profiles.yml.example
@@ -15,10 +15,9 @@ benefits:
 
     bigquery:
       type: bigquery
-      method: service-account
+      method: oauth
       project: "{{ env_var('GCP_PROJECT_ID') }}"
       dataset: analytics
       threads: 4
       timeout_seconds: 300
       location: US
-      keyfile: "{{ env_var('GOOGLE_APPLICATION_CREDENTIALS') }}"


### PR DESCRIPTION
## Summary

- Change dbt BigQuery target from `method: service-account` + `keyfile` to `method: oauth`
- The `google-github-actions/auth@v2` action writes a WIF external account credential file (not a SA key), so `method: service-account` fails with `gcloud auth application-default login` prompt
- `method: oauth` uses `google.auth.default()` which reads `GOOGLE_APPLICATION_CREDENTIALS` and handles WIF credentials correctly

## Test plan

- [ ] Merge, then trigger: `gh workflow run dbt-nightly.yml -f environment=staging`
- [ ] Verify BigQuery build step passes (previously failed with exit code 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the BigQuery profile configuration documentation example to demonstrate how to set up OAuth authentication instead of the previous service account-based authentication method.
  * Removed the service account key file path and its associated environment variable reference from the configuration example, making the setup instructions for BigQuery connections clearer and more straightforward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->