### PR TITLE
Document two-run requirement for new data sources

### DIFF
--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -66,6 +66,12 @@ resource "metabase_database" "tenant_postgres" {
 }
 
 # Wait for Metabase to sync database schemas before creating cards/dashboards
+#
+# NOTE: This only sleeps on initial creation. When enabling a NEW data source
+# (e.g. BigQuery for the first time), the sleep already exists in state and
+# won't re-trigger, so Metabase won't have time to discover the new tables.
+# The first apply will fail on the table lookup; just re-run the workflow and
+# the second apply will succeed once Metabase has finished syncing.
 resource "time_sleep" "wait_for_database_sync" {
   depends_on = [
     metabase_database.bigquery,


### PR DESCRIPTION
## Summary
- Adds a comment to `time_sleep.wait_for_database_sync` in `metabase.tf` explaining that the first `terraform apply` will fail when enabling a new data source (e.g. BigQuery) because the sleep already exists in state and won't re-trigger
- A second run succeeds after Metabase finishes syncing the new database

## Context
Discovered during Phase 2 Step 8 when enabling BigQuery on staging. The first terraform apply created the BigQuery data source but failed on the table lookup. The second run succeeded.

## Test plan
- [x] Comment-only change — verify no Terraform plan diff beyond the existing pending changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for the Metabase deployment process, clarifying expected behavior during initial setup and data source configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->