### PR TITLE
Migrate RLS from GUC-based to username-extraction

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -62,14 +62,22 @@ jobs:
             --arg pass "$GLOBAL_DB_PASS" \
             '{username: $user, password: $pass}')
           tenant_creds=$(jq -cn \
-            --arg nc_user "$NC_DB_USER" \
-            --arg nc_pass "$NC_DB_PASS" \
-            --arg co_user "$CO_DB_USER" \
-            --arg co_pass "$CO_DB_PASS" \
+            --arg nc_user "$NC_DB_USER" --arg nc_pass "$NC_DB_PASS" \
+            --arg co_user "$CO_DB_USER" --arg co_pass "$CO_DB_PASS" \
+            --arg tx_user "$TX_DB_USER" --arg tx_pass "$TX_DB_PASS" \
+            --arg il_user "$IL_DB_USER" --arg il_pass "$IL_DB_PASS" \
+            --arg ma_user "$MA_DB_USER" --arg ma_pass "$MA_DB_PASS" \
+            --arg cesn_user "$CESN_DB_USER" --arg cesn_pass "$CESN_DB_PASS" \
+            --arg cotc_user "$CO_TAX_CALCULATOR_DB_USER" --arg cotc_pass "$CO_TAX_CALCULATOR_DB_PASS" \
             '
               {}
               + (if $nc_user != "" and $nc_pass != "" then {nc: {username: $nc_user, password: $nc_pass}} else {} end)
               + (if $co_user != "" and $co_pass != "" then {co: {username: $co_user, password: $co_pass}} else {} end)
+              + (if $tx_user != "" and $tx_pass != "" then {tx: {username: $tx_user, password: $tx_pass}} else {} end)
+              + (if $il_user != "" and $il_pass != "" then {il: {username: $il_user, password: $il_pass}} else {} end)
+              + (if $ma_user != "" and $ma_pass != "" then {ma: {username: $ma_user, password: $ma_pass}} else {} end)
+              + (if $cesn_user != "" and $cesn_pass != "" then {cesn: {username: $cesn_user, password: $cesn_pass}} else {} end)
+              + (if $cotc_user != "" and $cotc_pass != "" then {co_tax_calculator: {username: $cotc_user, password: $cotc_pass}} else {} end)
             ')
           echo "TF_VAR_global_db_credentials=$global_creds" >> "$GITHUB_ENV"
           echo "TF_VAR_tenant_db_credentials=$tenant_creds" >> "$GITHUB_ENV"
@@ -80,6 +88,16 @@ jobs:
           NC_DB_PASS: ${{ secrets.NC_DB_PASS }}
           CO_DB_USER: ${{ secrets.CO_DB_USER }}
           CO_DB_PASS: ${{ secrets.CO_DB_PASS }}
+          TX_DB_USER: ${{ secrets.TX_DB_USER }}
+          TX_DB_PASS: ${{ secrets.TX_DB_PASS }}
+          IL_DB_USER: ${{ secrets.IL_DB_USER }}
+          IL_DB_PASS: ${{ secrets.IL_DB_PASS }}
+          MA_DB_USER: ${{ secrets.MA_DB_USER }}
+          MA_DB_PASS: ${{ secrets.MA_DB_PASS }}
+          CESN_DB_USER: ${{ secrets.CESN_DB_USER }}
+          CESN_DB_PASS: ${{ secrets.CESN_DB_PASS }}
+          CO_TAX_CALCULATOR_DB_USER: ${{ secrets.CO_TAX_CALCULATOR_DB_USER }}
+          CO_TAX_CALCULATOR_DB_PASS: ${{ secrets.CO_TAX_CALCULATOR_DB_PASS }}
 
       - name: Terraform Init
         run: terraform init

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -53,14 +53,22 @@ jobs:
             --arg pass "$GLOBAL_DB_PASS" \
             '{username: $user, password: $pass}')
           tenant_creds=$(jq -cn \
-            --arg nc_user "$NC_DB_USER" \
-            --arg nc_pass "$NC_DB_PASS" \
-            --arg co_user "$CO_DB_USER" \
-            --arg co_pass "$CO_DB_PASS" \
+            --arg nc_user "$NC_DB_USER" --arg nc_pass "$NC_DB_PASS" \
+            --arg co_user "$CO_DB_USER" --arg co_pass "$CO_DB_PASS" \
+            --arg tx_user "$TX_DB_USER" --arg tx_pass "$TX_DB_PASS" \
+            --arg il_user "$IL_DB_USER" --arg il_pass "$IL_DB_PASS" \
+            --arg ma_user "$MA_DB_USER" --arg ma_pass "$MA_DB_PASS" \
+            --arg cesn_user "$CESN_DB_USER" --arg cesn_pass "$CESN_DB_PASS" \
+            --arg cotc_user "$CO_TAX_CALCULATOR_DB_USER" --arg cotc_pass "$CO_TAX_CALCULATOR_DB_PASS" \
             '
               {}
               + (if $nc_user != "" and $nc_pass != "" then {nc: {username: $nc_user, password: $nc_pass}} else {} end)
               + (if $co_user != "" and $co_pass != "" then {co: {username: $co_user, password: $co_pass}} else {} end)
+              + (if $tx_user != "" and $tx_pass != "" then {tx: {username: $tx_user, password: $tx_pass}} else {} end)
+              + (if $il_user != "" and $il_pass != "" then {il: {username: $il_user, password: $il_pass}} else {} end)
+              + (if $ma_user != "" and $ma_pass != "" then {ma: {username: $ma_user, password: $ma_pass}} else {} end)
+              + (if $cesn_user != "" and $cesn_pass != "" then {cesn: {username: $cesn_user, password: $cesn_pass}} else {} end)
+              + (if $cotc_user != "" and $cotc_pass != "" then {co_tax_calculator: {username: $cotc_user, password: $cotc_pass}} else {} end)
             ')
           echo "TF_VAR_global_db_credentials=$global_creds" >> "$GITHUB_ENV"
           echo "TF_VAR_tenant_db_credentials=$tenant_creds" >> "$GITHUB_ENV"
@@ -71,6 +79,16 @@ jobs:
           NC_DB_PASS: ${{ secrets.NC_DB_PASS }}
           CO_DB_USER: ${{ secrets.CO_DB_USER }}
           CO_DB_PASS: ${{ secrets.CO_DB_PASS }}
+          TX_DB_USER: ${{ secrets.TX_DB_USER }}
+          TX_DB_PASS: ${{ secrets.TX_DB_PASS }}
+          IL_DB_USER: ${{ secrets.IL_DB_USER }}
+          IL_DB_PASS: ${{ secrets.IL_DB_PASS }}
+          MA_DB_USER: ${{ secrets.MA_DB_USER }}
+          MA_DB_PASS: ${{ secrets.MA_DB_PASS }}
+          CESN_DB_USER: ${{ secrets.CESN_DB_USER }}
+          CESN_DB_PASS: ${{ secrets.CESN_DB_PASS }}
+          CO_TAX_CALCULATOR_DB_USER: ${{ secrets.CO_TAX_CALCULATOR_DB_USER }}
+          CO_TAX_CALCULATOR_DB_PASS: ${{ secrets.CO_TAX_CALCULATOR_DB_PASS }}
 
       - name: Terraform Init
         run: terraform init

--- a/DEPLOYMENT_PLAN.md
+++ b/DEPLOYMENT_PLAN.md
@@ -246,7 +246,7 @@ Use GitHub Environments (`staging`, `production`) with environment-specific secr
 
 ### Prerequisite: Set Up RLS Database Users (one-time manual step)
 
-RLS uses **username-based filtering** everywhere (local and production). The dbt RLS macro and the `data_tenant` view both use the same pattern: `regexp_replace(current_user, '[^0-9]', '', 'g')::int` to extract the `white_label_id` from the credential name. Credential names must follow the convention `wl_<state>_<white_label_id>_ro`.
+RLS uses **username-based filtering** everywhere (local and production). The dbt RLS macro and the `data_tenant` view both use `regexp_match(current_user, '^wl_[a-z_]+_([0-9]+)_ro$')` to extract the `white_label_id` from the credential name. Only roles matching the `wl_<state>_<white_label_id>_ro` convention see data; non-conforming roles get zero rows.
 
 Table owners (the dbt build user) bypass RLS automatically in PostgreSQL.
 
@@ -704,7 +704,7 @@ Issues encountered during production deployment and their resolutions.
 
 **Issue:** `ALTER USER wl_nc_5_ro SET rls.white_label_id = '5'` fails with "permission denied" on Heroku. Custom GUC parameters require superuser, which Heroku doesn't grant.
 
-**Fix:** Use view-based RLS instead. A `data_tenant` view with `security_barrier` extracts the white_label_id from the credential username: `regexp_replace(current_user, '[^0-9]', '', 'g')::int`. Credential naming convention `wl_<state>_<id>_ro` embeds the ID.
+**Fix:** Use view-based RLS instead. A `data_tenant` view with `security_barrier` extracts the white_label_id from the credential username via `regexp_match(current_user, '^wl_[a-z_]+_([0-9]+)_ro$')`. Credential naming convention `wl_<state>_<id>_ro` embeds the ID.
 
 ### Pipeline Promotion Blocked for Container Registry Apps
 

--- a/DEPLOYMENT_PLAN.md
+++ b/DEPLOYMENT_PLAN.md
@@ -246,50 +246,38 @@ Use GitHub Environments (`staging`, `production`) with environment-specific secr
 
 ### Prerequisite: Set Up RLS Database Users (one-time manual step)
 
-#### Local Development (superuser available)
+RLS uses **username-based filtering** everywhere (local and production). The dbt RLS macro and the `data_tenant` view both use the same pattern: `regexp_replace(current_user, '[^0-9]', '', 'g')::int` to extract the `white_label_id` from the credential name. Credential names must follow the convention `wl_<state>_<white_label_id>_ro`.
 
-For local Postgres where you have superuser access, use GUC-based RLS:
+Table owners (the dbt build user) bypass RLS automatically in PostgreSQL.
+
+#### Local Development
 
 ```sql
-CREATE USER nc WITH PASSWORD '<password>';
-ALTER USER nc SET rls.white_label_id = '5';
-GRANT USAGE ON SCHEMA analytics TO nc;
-GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO nc;
+-- Create passwordless roles matching the naming convention
+CREATE ROLE wl_nc_5_ro LOGIN;     -- NC, white_label_id = 5
+CREATE ROLE wl_co_1_ro LOGIN;     -- CO, white_label_id = 1
 
-CREATE USER co WITH PASSWORD '<password>';
-ALTER USER co SET rls.white_label_id = '1';
-GRANT USAGE ON SCHEMA analytics TO co;
-GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO co;
+GRANT USAGE ON SCHEMA analytics TO wl_nc_5_ro, wl_co_1_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO wl_nc_5_ro, wl_co_1_ro;
 ```
 
-#### Heroku Production (no superuser)
+#### Heroku Production
 
-On Heroku, `ALTER USER ... SET` for custom GUC parameters requires superuser, which Heroku doesn't grant. Instead, use **view-based RLS** with Heroku credentials:
+On Heroku, create credentials via the CLI (Standard-tier+ only):
 
-1. **Credential naming convention:** `wl_<state>_<white_label_id>_ro` — the `data_tenant` view extracts the white_label_id from the username via `regexp_replace(current_user, '[^0-9]', '', 'g')::int`.
+```bash
+heroku pg:credentials:create -a cobenefits-api --name wl_co_1_ro
+heroku pg:credentials:url -a cobenefits-api --name wl_co_1_ro
+```
 
-2. **Create credentials:**
-   ```bash
-   heroku pg:credentials:create -a cobenefits-api --name wl_co_1_ro
-   heroku pg:credentials:url -a cobenefits-api --name wl_co_1_ro
-   ```
+Grant permissions (via `heroku pg:psql`):
 
-3. **Grant permissions** (via `heroku pg:psql`):
-   ```sql
-   GRANT USAGE ON SCHEMA analytics TO wl_co_1_ro;
-   GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO wl_co_1_ro;
-   GRANT USAGE ON SCHEMA public TO wl_co_1_ro;
-   GRANT SELECT ON public.data_tenant TO wl_co_1_ro;
-   ```
-
-4. **The `data_tenant` view** (already exists on production) handles row filtering:
-   ```sql
-   CREATE VIEW public.data_tenant
-   WITH (security_barrier = TRUE)
-   AS
-   SELECT * FROM public.data
-   WHERE white_label_id = regexp_replace(current_user, '[^0-9]', '', 'g')::int;
-   ```
+```sql
+GRANT USAGE ON SCHEMA analytics TO wl_co_1_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO wl_co_1_ro;
+GRANT USAGE ON SCHEMA public TO wl_co_1_ro;
+GRANT SELECT ON public.data_tenant TO wl_co_1_ro;
+```
 
 #### Staging (Essential-tier)
 

--- a/dashboards/GITHUB_SECRETS.md
+++ b/dashboards/GITHUB_SECRETS.md
@@ -123,19 +123,17 @@ Same secrets/variables as staging, but with **production values**:
 
 ### Production Database Users (RLS)
 
-Production uses Heroku Postgres Standard-tier, which supports multiple credentials. The RLS approach uses a **view-based filter** rather than GUC parameters (which require superuser that Heroku doesn't grant).
+Production uses Heroku Postgres Standard-tier, which supports multiple credentials. RLS is enforced by extracting the `white_label_id` from the credential username via `regexp_replace(current_user, '[^0-9]', '', 'g')::int`.
 
-**How RLS works:** A `data_tenant` view extracts the `white_label_id` from the connecting username:
-```sql
-CREATE VIEW public.data_tenant
-WITH (security_barrier = TRUE)
-AS
-SELECT *
-FROM public.data
-WHERE white_label_id = regexp_replace(current_user, '[^0-9]', '', 'g')::int;
-```
+This same pattern is used in two places:
+- **dbt analytics tables** — the RLS policy in `dbt/macros/row_level_security.sql` filters rows by the extracted ID
+- **`data_tenant` view** — a `security_barrier` view in `public` schema that filters the legacy `data` table the same way
 
-This means credential names must embed the white_label_id: `wl_nc_5_ro` → extracts `5`, `wl_co_1_ro` → extracts `1`.
+Credential names must follow the convention `wl_<state>_<white_label_id>_ro`:
+- `wl_nc_5_ro` → extracts `5` (NC)
+- `wl_co_1_ro` → extracts `1` (CO)
+
+Table owners (the dbt build user) bypass RLS automatically in PostgreSQL.
 
 **Creating credentials:**
 
@@ -163,8 +161,6 @@ GRANT SELECT ON public.data_tenant TO wl_co_1_ro;
 ALTER DEFAULT PRIVILEGES FOR USER <default_credential_user> IN SCHEMA analytics
   GRANT SELECT ON TABLES TO wl_co_1_ro;
 ```
-
-**Important:** `ALTER USER ... SET rls.white_label_id` does NOT work on Heroku — it requires superuser privileges. The view-based approach above is the production pattern. The GUC-based approach (`ALTER USER ... SET`) only works in local development where you have superuser access.
 
 ### Production Credentials Reference
 

--- a/dashboards/GITHUB_SECRETS.md
+++ b/dashboards/GITHUB_SECRETS.md
@@ -123,7 +123,7 @@ Same secrets/variables as staging, but with **production values**:
 
 ### Production Database Users (RLS)
 
-Production uses Heroku Postgres Standard-tier, which supports multiple credentials. RLS is enforced by extracting the `white_label_id` from the credential username via `regexp_replace(current_user, '[^0-9]', '', 'g')::int`.
+Production uses Heroku Postgres Standard-tier, which supports multiple credentials. RLS is enforced by extracting the `white_label_id` from the credential username via `regexp_match(current_user, '^wl_[a-z_]+_([0-9]+)_ro$')`.
 
 This same pattern is used in two places:
 - **dbt analytics tables** — the RLS policy in `dbt/macros/row_level_security.sql` filters rows by the extracted ID
@@ -167,8 +167,13 @@ ALTER DEFAULT PRIVILEGES FOR USER <default_credential_user> IN SCHEMA analytics
 | GitHub Secret | Heroku Credential | Purpose |
 |---------------|-------------------|---------|
 | `GLOBAL_DB_USER/PASS` | `default` | dbt writes + global Metabase access |
-| `NC_DB_USER/PASS` | `wl_nc_5_ro` | NC tenant Metabase (RLS via view) |
-| `CO_DB_USER/PASS` | `wl_co_1_ro` | CO tenant Metabase (RLS via view) |
+| `NC_DB_USER/PASS` | `wl_nc_5_ro` | NC tenant Metabase (white_label_id=5) |
+| `CO_DB_USER/PASS` | `wl_co_1_ro` | CO tenant Metabase (white_label_id=1) |
+| `TX_DB_USER/PASS` | `wl_tx_40_ro` | TX tenant Metabase (white_label_id=40) |
+| `IL_DB_USER/PASS` | `wl_il_39_ro` | IL tenant Metabase (white_label_id=39) |
+| `MA_DB_USER/PASS` | `wl_ma_38_ro` | MA tenant Metabase (white_label_id=38) |
+| `CESN_DB_USER/PASS` | `wl_cesn_4_ro` | CESN tenant Metabase (white_label_id=4) |
+| `CO_TAX_CALCULATOR_DB_USER/PASS` | `wl_co_tax_calculator_3_ro` | CO Tax Calculator Metabase (white_label_id=3) |
 
 ### Variables (Settings → Environments → production → Variables)
 
@@ -195,6 +200,16 @@ ALTER DEFAULT PRIVILEGES FOR USER <default_credential_user> IN SCHEMA analytics
 | `NC_DB_PASS` | NC tenant credential password | Same as above |
 | `CO_DB_USER` | CO tenant credential username | `heroku pg:credentials:url -a cobenefits-api --name wl_co_1_ro` |
 | `CO_DB_PASS` | CO tenant credential password | Same as above |
+| `TX_DB_USER` | TX tenant credential username | `heroku pg:credentials:url -a cobenefits-api --name wl_tx_40_ro` |
+| `TX_DB_PASS` | TX tenant credential password | Same as above |
+| `IL_DB_USER` | IL tenant credential username | `heroku pg:credentials:url -a cobenefits-api --name wl_il_39_ro` |
+| `IL_DB_PASS` | IL tenant credential password | Same as above |
+| `MA_DB_USER` | MA tenant credential username | `heroku pg:credentials:url -a cobenefits-api --name wl_ma_38_ro` |
+| `MA_DB_PASS` | MA tenant credential password | Same as above |
+| `CESN_DB_USER` | CESN tenant credential username | `heroku pg:credentials:url -a cobenefits-api --name wl_cesn_4_ro` |
+| `CESN_DB_PASS` | CESN tenant credential password | Same as above |
+| `CO_TAX_CALCULATOR_DB_USER` | CO Tax Calculator credential username | `heroku pg:credentials:url -a cobenefits-api --name wl_co_tax_calculator_3_ro` |
+| `CO_TAX_CALCULATOR_DB_PASS` | CO Tax Calculator credential password | Same as above |
 | `BIGQUERY_SA_KEY` | BigQuery service account key (JSON) | Same key as staging |
 
 ---

--- a/dashboards/terraform.tfvars.example
+++ b/dashboards/terraform.tfvars.example
@@ -13,7 +13,7 @@ global_db_credentials = {
 
 # Tenant-Specific Database Credentials (RLS Users)
 # Convention: wl_<state>_<white_label_id>_ro — the RLS policy extracts the
-# white_label_id from the username via regexp_replace(current_user, '[^0-9]', '', 'g')
+# white_label_id from the username via regexp_match(current_user, '^wl_[a-z_]+_([0-9]+)_ro$')
 tenant_db_credentials = {
   nc = {
     username = "wl_nc_5_ro"              # white_label_id = 5

--- a/dashboards/terraform.tfvars.example
+++ b/dashboards/terraform.tfvars.example
@@ -12,34 +12,36 @@ global_db_credentials = {
 }
 
 # Tenant-Specific Database Credentials (RLS Users)
+# Convention: wl_<state>_<white_label_id>_ro — the RLS policy extracts the
+# white_label_id from the username via regexp_replace(current_user, '[^0-9]', '', 'g')
 tenant_db_credentials = {
   nc = {
-    username = "nc"
-    password = "your_password"  # NC user password
+    username = "wl_nc_5_ro"              # white_label_id = 5
+    password = "your_password"
   }
   co = {
-    username = "co"
-    password = "your_password"  # CO user password
+    username = "wl_co_1_ro"              # white_label_id = 1
+    password = "your_password"
   }
   tx = {
-    username = "tx"
-    password = "your_password"  # TX user password
+    username = "wl_tx_40_ro"             # white_label_id = 40
+    password = "your_password"
   }
   il = {
-    username = "il"
-    password = "your_password"  # IL user password
+    username = "wl_il_39_ro"             # white_label_id = 39
+    password = "your_password"
   }
   ma = {
-    username = "ma"
-    password = "your_password"  # MA user password
+    username = "wl_ma_38_ro"             # white_label_id = 38
+    password = "your_password"
   }
   cesn = {
-    username = "cesn"
-    password = "your_password"  # CESN user password
+    username = "wl_cesn_4_ro"            # white_label_id = 4
+    password = "your_password"
   }
   co_tax_calculator = {
-    username = "co_tax_calculator"
-    password = "your_password"  # CO Tax Calculator user password
+    username = "wl_co_tax_calculator_3_ro"  # white_label_id = 3
+    password = "your_password"
   }
 }
 

--- a/data-queries/data_tenant.sql
+++ b/data-queries/data_tenant.sql
@@ -6,7 +6,7 @@ SELECT *
 FROM public.data                    -- your existing MV
 WHERE
     white_label_id
-    = regexp_replace(current_user, '[^0-9]', '', 'g')::int;
+    = (regexp_match(current_user, '^wl_[a-z_]+_([0-9]+)_ro$'))[1]::int;
 
 -- Restore permissions (adjust role names as needed based on your environment)
 GRANT USAGE ON SCHEMA public TO wl_nc_5_ro;

--- a/data-queries/data_tenant.sql
+++ b/data-queries/data_tenant.sql
@@ -8,6 +8,10 @@ WHERE
     white_label_id
     = (regexp_match(current_user, '^wl_[a-z_]+_([0-9]+)_ro$'))[1]::int;
 
--- Restore permissions (adjust role names as needed based on your environment)
+-- Grant permissions to each tenant role (repeat for every wl_<state>_<id>_ro credential)
+-- Example for NC (white_label_id=5):
 GRANT USAGE ON SCHEMA public TO wl_nc_5_ro;
 GRANT SELECT ON public.data_tenant TO wl_nc_5_ro;
+-- Example for CO (white_label_id=1):
+-- GRANT USAGE ON SCHEMA public TO wl_co_1_ro;
+-- GRANT SELECT ON public.data_tenant TO wl_co_1_ro;

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -137,48 +137,39 @@ All models with white label data should use RLS. Add this post-hook to enable ro
 
 #### Creating Test Users for Local Development
 
-⚠️ **For local development only.** Production user provisioning should be handled via infrastructure-as-code (Terraform, CI/CD pipelines, etc.) with proper secrets management.
+⚠️ **For local development only.** Production credentials are provisioned via `heroku pg:credentials:create`.
 
-Use `psql` to create test users with secure password handling:
+RLS uses **username-based filtering** — the policy extracts the `white_label_id` from the connecting role's name via `regexp_replace(current_user, '[^0-9]', '', 'g')`. Credential names must follow the convention `wl_<state>_<white_label_id>_ro`.
 
-```bash
-# Option 1: Interactive password prompt (most secure - password not logged)
-psql -h localhost -U postgres << 'EOF'
-\prompt 'Enter password for user: ' user_password
-CREATE USER nc WITH PASSWORD :'user_password';
-ALTER USER nc SET rls.white_label_id = '1';
-GRANT CONNECT ON DATABASE your_database TO nc;
-GRANT USAGE ON SCHEMA your_schema TO nc;
-GRANT SELECT ON ALL TABLES IN SCHEMA your_schema TO nc;
-EOF
+The dbt build user (table owner) bypasses RLS automatically in PostgreSQL — no special handling needed.
 
-# Option 2: Using environment variable (keeps password out of shell history)
-export DB_PASSWORD="secure_password"
-psql -h localhost -U postgres << EOF
--- Create user for North Carolina (white_label_id = 1)
-CREATE USER nc WITH PASSWORD '$DB_PASSWORD';
-ALTER USER nc SET rls.white_label_id = '1';
-GRANT CONNECT ON DATABASE your_database TO nc;
-GRANT USAGE ON SCHEMA your_schema TO nc;
-GRANT SELECT ON ALL TABLES IN SCHEMA your_schema TO nc;
+```sql
+-- Connect as your local superuser (e.g. postgres or your OS username)
+-- Create passwordless roles for local development
 
--- Create user for Colorado (white_label_id = 7)
-CREATE USER co WITH PASSWORD '$DB_PASSWORD';
-ALTER USER co SET rls.white_label_id = '7';
-GRANT CONNECT ON DATABASE your_database TO co;
-GRANT USAGE ON SCHEMA your_schema TO co;
-GRANT SELECT ON ALL TABLES IN SCHEMA your_schema TO co;
+CREATE ROLE wl_nc_5_ro LOGIN;          -- NC, white_label_id = 5
+CREATE ROLE wl_co_1_ro LOGIN;          -- CO, white_label_id = 1
+CREATE ROLE wl_tx_40_ro LOGIN;         -- TX, white_label_id = 40
+CREATE ROLE wl_il_39_ro LOGIN;         -- IL, white_label_id = 39
+CREATE ROLE wl_ma_38_ro LOGIN;         -- MA, white_label_id = 38
+CREATE ROLE wl_cesn_4_ro LOGIN;        -- CESN, white_label_id = 4
+CREATE ROLE wl_co_tax_calculator_3_ro LOGIN;  -- CO Tax Calculator, white_label_id = 3
 
--- Create admin user with BYPASSRLS (sees all data)
-CREATE USER admin_user WITH PASSWORD '$DB_PASSWORD' BYPASSRLS;
-GRANT CONNECT ON DATABASE your_database TO admin_user;
-GRANT USAGE ON SCHEMA your_schema TO admin_user;
-GRANT SELECT ON ALL TABLES IN SCHEMA your_schema TO admin_user;
-EOF
-unset DB_PASSWORD
+-- Grant access to the analytics schema
+GRANT USAGE ON SCHEMA analytics TO wl_nc_5_ro, wl_co_1_ro, wl_tx_40_ro,
+  wl_il_39_ro, wl_ma_38_ro, wl_cesn_4_ro, wl_co_tax_calculator_3_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO wl_nc_5_ro, wl_co_1_ro,
+  wl_tx_40_ro, wl_il_39_ro, wl_ma_38_ro, wl_cesn_4_ro, wl_co_tax_calculator_3_ro;
 ```
 
-**Note:** Replace `your_database` and `your_schema` with your actual database and schema names. The specific `white_label_id` values depend on your data.
+**Verifying RLS:**
+
+```sql
+SET ROLE wl_nc_5_ro;
+SELECT count(*), white_label_id FROM analytics.mart_screener_data GROUP BY white_label_id;
+-- Should show only white_label_id = 5
+RESET ROLE;
+```
 
 
 ## BigQuery Setup (Optional)

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -139,7 +139,7 @@ All models with white label data should use RLS. Add this post-hook to enable ro
 
 ⚠️ **For local development only.** Production credentials are provisioned via `heroku pg:credentials:create`.
 
-RLS uses **username-based filtering** — the policy extracts the `white_label_id` from the connecting role's name via `regexp_replace(current_user, '[^0-9]', '', 'g')`. Credential names must follow the convention `wl_<state>_<white_label_id>_ro`.
+RLS uses **username-based filtering** — the policy extracts the `white_label_id` from the connecting role's name via `regexp_match(current_user, '^wl_[a-z_]+_([0-9]+)_ro$')`. Only roles matching the `wl_<state>_<white_label_id>_ro` convention see data; non-conforming roles get zero rows.
 
 The dbt build user (table owner) bypasses RLS automatically in PostgreSQL — no special handling needed.
 

--- a/dbt/macros/row_level_security.sql
+++ b/dbt/macros/row_level_security.sql
@@ -30,12 +30,13 @@
   -- Create RLS policy that extracts white_label_id from the username
   -- Convention: credential names follow wl_<state>_<id>_ro (e.g. wl_nc_5_ro → 5)
   -- Table owners (dbt build user) bypass RLS automatically in PostgreSQL
+  -- Non-conforming role names yield NULL → no rows (safe denial)
   CREATE POLICY {{ policy_name }}
     ON {{ full_table_name }}
     FOR ALL
     TO PUBLIC
     USING (
-      {{ white_label_column }} = NULLIF(regexp_replace(current_user, '[^0-9]', '', 'g'), '')::int
+      {{ white_label_column }} = (regexp_match(current_user, '^wl_[a-z_]+_([0-9]+)_ro$'))[1]::int
     );
 
   -- Grant necessary permissions

--- a/dbt/macros/row_level_security.sql
+++ b/dbt/macros/row_level_security.sql
@@ -27,16 +27,15 @@
   -- Drop existing policy if it exists
   DROP POLICY IF EXISTS {{ policy_name }} ON {{ full_table_name }};
 
-  -- Create RLS policy that filters by user's white label setting
+  -- Create RLS policy that extracts white_label_id from the username
+  -- Convention: credential names follow wl_<state>_<id>_ro (e.g. wl_nc_5_ro → 5)
+  -- Table owners (dbt build user) bypass RLS automatically in PostgreSQL
   CREATE POLICY {{ policy_name }}
     ON {{ full_table_name }}
     FOR ALL
     TO PUBLIC
     USING (
-      {{ white_label_column }} = COALESCE(
-        NULLIF(current_setting('rls.white_label_id', true), '')::integer,
-        -999999  -- Deny access if no white_label_id is set
-      )
+      {{ white_label_column }} = NULLIF(regexp_replace(current_user, '[^0-9]', '', 'g'), '')::int
     );
 
   -- Grant necessary permissions


### PR DESCRIPTION
## Summary

- **Replace GUC-based RLS** (`current_setting('rls.white_label_id')`) with username-extraction (`regexp_replace(current_user, '[^0-9]', '', 'g')::int`) in the dbt RLS macro
- **Fix 5 tenant credential names** in `terraform.tfvars.example` to match actual production `white_label_id` values (tx=40, il=39, ma=38, cesn=4, co_tax_calculator=3)
- **Update all documentation** (dbt README, DEPLOYMENT_PLAN, GITHUB_SECRETS) to remove GUC references and document the username-based convention

## Why

The GUC approach requires `ALTER ROLE ... SET rls.white_label_id`, which needs **superuser** — a privilege Heroku Postgres doesn't grant. This caused NC/CO dedicated credentials (`wl_nc_5_ro`, `wl_co_1_ro`) to see **zero rows** in production because their GUC was never set.

The new approach extracts the `white_label_id` from the credential name (e.g. `wl_nc_5_ro` → `5`), matching the pattern already used by the `data_tenant` view. It works on both local dev (passwordless roles) and Heroku (no superuser needed).

## Test plan

- [x] `dbt build --target postgres` — all 104 models/tests pass
- [x] RLS verified via `SET ROLE` for all 7 tenants — each sees only their own `white_label_id`
- [x] Table owner bypasses RLS and sees all data
- [x] Metabase tenant dashboards show correct counts (NC=11,999, CO=64,039, TX=17)
- [ ] After merge, trigger `dbt-nightly` for production — rebuilds analytics tables with new RLS policy
- [ ] Verify NC/CO production credentials see their respective data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized username-based credential convention across deployment and dbt docs, updated local and production setup instructions, added RLS verification guidance, and expanded production credential references/examples.
* **Bug Fixes**
  * Clarified RLS filtering to derive tenant ID from credential usernames using a safer matching approach; documented table-owner bypass behavior.
* **Chores**
  * Updated example configuration and CI/workflow steps to accept and package additional tenant credentials (TX, IL, MA, CESN, CO tax calculator).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->