### PR TITLE
Create Non-NC Dashboards

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -107,7 +107,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const plan = fs.readFileSync('dashboards/plan_output.txt', 'utf8');
+            let plan = fs.readFileSync('dashboards/plan_output.txt', 'utf8');
+            const maxLen = 60000;
+            if (plan.length > maxLen) {
+              plan = plan.substring(0, maxLen) + '\n\n... (truncated — full plan is ' + fs.statSync('dashboards/plan_output.txt').size + ' bytes)';
+            }
             const output = `#### Terraform Plan 📖
 
             <details><summary>Show Plan</summary>

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ venv/
 terraform.tfvars
 local_override.tf
 *.tfplan
+tfplan
 
 # dashboards scripts
 dashboards/scripts/generated/

--- a/BIGQUERY_INTEGRATION.md
+++ b/BIGQUERY_INTEGRATION.md
@@ -192,11 +192,10 @@ Metabase's BigQuery driver expects a service account JSON key. The `mfb-data` pr
      --role="roles/bigquery.jobUser"
    ```
 
-3. Temporarily disable the org policy to allow key creation (requires `roles/orgpolicy.policyAdmin` on org `1001672396356`):
+3. Temporarily disable the org policy **at the project level only** to allow key creation (requires `roles/orgpolicy.policyAdmin`):
    ```bash
-   # Remove the policy at both org and project levels
-   gcloud org-policies delete iam.disableServiceAccountKeyCreation --organization=1001672396356
-   gcloud resource-manager org-policies delete iam.disableServiceAccountKeyCreation --project=mfb-data
+   # Override the org policy at the project level (does NOT affect the organization)
+   gcloud resource-manager org-policies disable-enforce iam.disableServiceAccountKeyCreation --project=mfb-data
 
    # Create the key
    gcloud iam service-accounts keys create metabase-bigquery-key.json \
@@ -204,17 +203,16 @@ Metabase's BigQuery driver expects a service account JSON key. The `mfb-data` pr
      --project=mfb-data
    ```
 
-4. **Immediately** re-enable the org policy at both levels:
+4. **Immediately** re-enable the policy at the project level:
    ```bash
    gcloud resource-manager org-policies enable-enforce iam.disableServiceAccountKeyCreation --project=mfb-data
-   gcloud resource-manager org-policies enable-enforce iam.disableServiceAccountKeyCreation --organization=1001672396356
    ```
 
-   > **Important:** Do not skip this step. The policy must be re-enabled at both the project and organization levels to prevent unauthorized key creation.
+   > **Important:** Do not skip this step. The project-level override must be re-enabled to prevent unauthorized key creation.
 
 5. Store the key content as `BIGQUERY_SA_KEY` GitHub Environment secret (Terraform passes it to Metabase via API)
 
-**Key rotation:** Service account keys should be rotated periodically. Repeat steps 3-5: temporarily disable the org policy, create a new key, update the GitHub secret, run `terraform apply`, delete the old key, re-enable the org policy.
+**Key rotation:** Service account keys should be rotated periodically. Repeat steps 3-5: temporarily disable the project-level policy, create a new key, update the GitHub secret, run `terraform apply`, delete the old key, re-enable the project-level policy.
 
 ## Environment Variables Summary
 

--- a/BIGQUERY_INTEGRATION.md
+++ b/BIGQUERY_INTEGRATION.md
@@ -194,27 +194,23 @@ Metabase's BigQuery driver expects a service account JSON key. The `mfb-data` pr
 
 3. Temporarily disable the org policy to allow key creation (requires `roles/orgpolicy.policyAdmin` on org `1001672396356`):
    ```bash
-   # Create a policy override file
-   cat > /tmp/org-policy-override.yaml <<'EOF'
-   name: projects/mfb-data/policies/iam.disableServiceAccountKeyCreation
-   spec:
-     rules:
-     - enforce: false
-   EOF
+   # Remove the policy at both org and project levels
+   gcloud org-policies delete iam.disableServiceAccountKeyCreation --organization=1001672396356
+   gcloud resource-manager org-policies delete iam.disableServiceAccountKeyCreation --project=mfb-data
 
-   # Apply the override
-   gcloud org-policies set-policy /tmp/org-policy-override.yaml --project=mfb-data
-
-   # Wait ~60 seconds for propagation, then create the key
+   # Create the key
    gcloud iam service-accounts keys create metabase-bigquery-key.json \
-     --iam-account=metabase-bigquery@mfb-data.iam.gserviceaccount.com
+     --iam-account=metabase-bigquery@mfb-data.iam.gserviceaccount.com \
+     --project=mfb-data
    ```
 
-4. Re-enable the org policy after key creation:
+4. **Immediately** re-enable the org policy at both levels:
    ```bash
-   gcloud org-policies delete iam.disableServiceAccountKeyCreation --project=mfb-data
+   gcloud resource-manager org-policies enable-enforce iam.disableServiceAccountKeyCreation --project=mfb-data
+   gcloud resource-manager org-policies enable-enforce iam.disableServiceAccountKeyCreation --organization=1001672396356
    ```
-   This removes the project-level override so the org-level enforcement is inherited again.
+
+   > **Important:** Do not skip this step. The policy must be re-enabled at both the project and organization levels to prevent unauthorized key creation.
 
 5. Store the key content as `BIGQUERY_SA_KEY` GitHub Environment secret (Terraform passes it to Metabase via API)
 

--- a/dashboards/.terraform.lock.hcl
+++ b/dashboards/.terraform.lock.hcl
@@ -24,6 +24,25 @@ provider "registry.terraform.io/flovouin/metabase" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.3.5"
+  hashes = [
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
+    "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
+    "zh:a2ce38fda83a62fa5fb5a70e6ca8453b168575feb3459fa39803f6f40bd42154",
+    "zh:a6c72798f4a9a36d1d1433c0372006cc9b904e8cfd60a2ae03ac5b7d2abd2398",
+    "zh:a8a3141d2fc71c86bf7f3c13b0b3be8a1b0f0144a47572a15af4dfafc051e28a",
+    "zh:aa20a1242eb97445ad26ebcfb9babf2cd675bdb81cac5f989268ebefa4ef278c",
+    "zh:b58a22445fb8804e933dcf835ab06c29a0f33148dce61316814783ee7f4e4332",
+    "zh:cb5626a661ee761e0576defb2a2d75230a3244799d380864f3089c66e99d0dcc",
+    "zh:d1acb00d20445f682c4e705c965e5220530209c95609194c2dc39324f3d4fcce",
+    "zh:d91a254ba77b69a29d8eae8ed0e9367cbf0ea6ac1a85b58e190f8cb096a40871",
+    "zh:f6592327673c9f85cdb6f20336faef240abae7621b834f189c4a62276ea5db41",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/time" {
   version = "0.13.1"
   hashes = [

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -209,8 +209,9 @@ Find the **"Data Dashboards BigQuery Key (Localhost)"** entry in the MyFriendBen
 
 ```bash
 mkdir -p secrets
-# Paste the JSON content into this file:
-pbpaste > secrets/bigquerykey.json
+# Create secrets/bigquerykey.json and paste the JSON content into it.
+# macOS example:
+# pbpaste > secrets/bigquerykey.json
 ```
 
 **2. Enable BigQuery in Terraform**

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -7,7 +7,7 @@ Metabase infrastructure deployed through terraform with multi-tenant analytics.
 ### Prerequisites
 
 - Docker and Docker Compose installed
-- BigQuery service account key saved to `./secrets/bigquerykey.json` (or customize path via `bigquery_service_account_key_path` in terraform.tfvars)
+- BigQuery service account key (see [BigQuery Setup](#bigquery-setup) below)
 
 ### Setup Steps
 
@@ -36,7 +36,7 @@ Open http://localhost:3001 in your browser (or the URL shown by the setup script
 Each tenant needs a dedicated database user that only has access to their white-label data.
 
 **Important:** Before running these commands:
-- Replace `white_label_id` values with the correct IDs from your My Friend Ben database
+- Replace `white_label_id` values with the correct IDs from your MyFriendBen database
 - Update the database name (`mfb`) and credentials to match your local setup
 
 ```bash
@@ -151,7 +151,7 @@ locals {
 
 Create a new database user with row-level security (see Quick Start step 3 for detailed instructions).
 
-**Note:** Check your My Friend Ben database to find the correct `white_label_id` for the new tenant.
+**Note:** Check your MyFriendBen database to find the correct `white_label_id` for the new tenant.
 
 ```bash
 export DB_PASSWORD="secure_password"
@@ -198,6 +198,41 @@ instance — see the Quick Start section above for that setup.
 
 `local_override.tf` is gitignored — CI/CD never sees it, so GitHub Actions
 continues using Terraform Cloud for staging and production.
+
+## BigQuery Setup
+
+The Google Analytics tab requires a BigQuery connection. To enable it locally:
+
+**1. Get the service account key from 1Password**
+
+Find the **"Data Dashboards BigQuery Key (Localhost)"** entry in the MyFriendBen 1Password vault. Copy the JSON content and save it:
+
+```bash
+mkdir -p secrets
+# Paste the JSON content into this file:
+pbpaste > secrets/bigquerykey.json
+```
+
+**2. Enable BigQuery in Terraform**
+
+In `terraform.tfvars`, set:
+
+```hcl
+bigquery_enabled = true
+```
+
+**3. Restart Metabase and apply**
+
+```bash
+docker restart metabase
+terraform apply
+```
+
+The first apply after enabling BigQuery may need a second run — Metabase takes a moment to sync the BigQuery schema before Terraform can reference its tables.
+
+> **Important:** The BigQuery service account key grants direct access to MyFriendBen analytics data. Do not share it with anyone outside of MyFriendBen.
+>
+> The `secrets/` directory is gitignored. Never commit service account keys to the repository.
 
 ## Troubleshooting
 

--- a/dashboards/benefits_and_immediate_needs.tf
+++ b/dashboards/benefits_and_immediate_needs.tf
@@ -66,18 +66,7 @@ resource "metabase_card" "tenant_current_benefits_table" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query = <<EOF
-WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data)
-SELECT 
-    benefit as "Benefit Name",
-    SUM(count) as "# of Screeners",
-    SUM(count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
-FROM analytics.mart_previous_benefits
-CROSS JOIN totals t
-GROUP BY benefit
-HAVING SUM(count) > 0
-ORDER BY SUM(count) DESC
-EOF
+        query = templatefile("${path.module}/sql/current_benefits.sql", {})
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -98,19 +87,7 @@ resource "metabase_card" "tenant_qualified_benefits_table" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query = <<EOF
-WITH totals AS (
-    SELECT count(*) as total_count FROM analytics.mart_screener_data
-)
-SELECT 
-    qb.benefit as "Benefit Name",
-    SUM(qb.count) as "# of Screeners",
-    SUM(qb.count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
-FROM analytics.mart_qualified_benefits qb
-CROSS JOIN totals t
-GROUP BY qb.benefit
-ORDER BY SUM(qb.count) DESC
-EOF
+        query = templatefile("${path.module}/sql/qualified_benefits.sql", {})
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -130,17 +107,7 @@ resource "metabase_card" "tenant_immediate_needs_table" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query = <<EOF
-WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data)
-SELECT 
-    benefit as "Need Category",
-    SUM(count) as "# of Screeners",
-    SUM(count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
-FROM analytics.mart_immediate_needs
-CROSS JOIN totals t
-GROUP BY benefit
-ORDER BY SUM(count) DESC
-EOF
+        query = templatefile("${path.module}/sql/immediate_needs.sql", {})
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {

--- a/dashboards/benefits_and_immediate_needs.tf
+++ b/dashboards/benefits_and_immediate_needs.tf
@@ -78,7 +78,8 @@ resource "metabase_card" "tenant_current_benefits_table" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query = templatefile("${path.module}/sql/current_benefits.sql", {})
+        query           = templatefile("${path.module}/sql/current_benefits.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -99,7 +100,8 @@ resource "metabase_card" "tenant_qualified_benefits_table" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query = templatefile("${path.module}/sql/qualified_benefits.sql", {})
+        query           = templatefile("${path.module}/sql/qualified_benefits.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -119,7 +121,8 @@ resource "metabase_card" "tenant_immediate_needs_table" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query = templatefile("${path.module}/sql/immediate_needs.sql", {})
+        query           = templatefile("${path.module}/sql/immediate_needs.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -229,35 +232,47 @@ locals {
         visualization_settings = {}
       },
       {
-        card_id                = tonumber(metabase_card.tenant_current_benefits_table[k].id)
-        dashboard_tab_id       = 5
-        row                    = 6
-        col                    = 0
-        size_x                 = 12
-        size_y                 = 8
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_current_benefits_table[k].id)
+        dashboard_tab_id = 5
+        row              = 6
+        col              = 0
+        size_x           = 12
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_current_benefits_table[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },
       {
-        card_id                = tonumber(metabase_card.tenant_qualified_benefits_table[k].id)
-        dashboard_tab_id       = 5
-        row                    = 6
-        col                    = 12
-        size_x                 = 12
-        size_y                 = 8
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_qualified_benefits_table[k].id)
+        dashboard_tab_id = 5
+        row              = 6
+        col              = 12
+        size_x           = 12
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_qualified_benefits_table[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },
       {
-        card_id                = tonumber(metabase_card.tenant_immediate_needs_table[k].id)
-        dashboard_tab_id       = 5
-        row                    = 14
-        col                    = 0
-        size_x                 = 12
-        size_y                 = 8
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_immediate_needs_table[k].id)
+        dashboard_tab_id = 5
+        row              = 14
+        col              = 0
+        size_x           = 12
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_immediate_needs_table[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       }

--- a/dashboards/benefits_and_immediate_needs.tf
+++ b/dashboards/benefits_and_immediate_needs.tf
@@ -7,7 +7,10 @@ resource "metabase_card" "tenant_completed_screeners" {
     dataset_query = {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
-      native   = { query = "SELECT count(*) AS \"Completed Screeners\" FROM analytics.mart_screener_data" }
+      native = {
+        query           = "SELECT count(*) AS \"Completed Screeners\" FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
     }
     visualization_settings = { "scalar.field" = "count" }
   }))
@@ -35,7 +38,10 @@ resource "metabase_card" "tenant_qualified_for_benefits_pct" {
     dataset_query = {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
-      native   = { query = "SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data" }
+      native = {
+        query           = "SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
     }
     visualization_settings = local.benefits_pct_visualization_settings
   }))
@@ -49,7 +55,10 @@ resource "metabase_card" "tenant_qualified_for_tax_creds_pct" {
     dataset_query = {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
-      native   = { query = "SELECT count(*) FILTER (WHERE tax_credits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data" }
+      native = {
+        query           = "SELECT count(*) FILTER (WHERE tax_credits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
     }
     visualization_settings = local.benefits_pct_visualization_settings
   }))

--- a/dashboards/benefits_and_immediate_needs.tf
+++ b/dashboards/benefits_and_immediate_needs.tf
@@ -24,7 +24,10 @@ resource "metabase_card" "tenant_already_had_benefits_pct" {
     dataset_query = {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
-      native   = { query = "SELECT count(*) FILTER (WHERE has_benefits = 'true')::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data" }
+      native = {
+        query           = "SELECT count(*) FILTER (WHERE has_benefits = 'true')::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
     }
     visualization_settings = local.benefits_pct_visualization_settings
   }))
@@ -166,46 +169,62 @@ locals {
         }
       },
       {
-        card_id                = tonumber(metabase_card.tenant_completed_screeners[k].id)
-        dashboard_tab_id       = 5
-        row                    = 2
-        col                    = 0
-        size_x                 = 6
-        size_y                 = 4
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_completed_screeners[k].id)
+        dashboard_tab_id = 5
+        row              = 2
+        col              = 0
+        size_x           = 6
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_completed_screeners[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },
       {
-        card_id                = tonumber(metabase_card.tenant_already_had_benefits_pct[k].id)
-        dashboard_tab_id       = 5
-        row                    = 2
-        col                    = 6
-        size_x                 = 6
-        size_y                 = 4
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_already_had_benefits_pct[k].id)
+        dashboard_tab_id = 5
+        row              = 2
+        col              = 6
+        size_x           = 6
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_already_had_benefits_pct[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },
       {
-        card_id                = tonumber(metabase_card.tenant_qualified_for_benefits_pct[k].id)
-        dashboard_tab_id       = 5
-        row                    = 2
-        col                    = 12
-        size_x                 = 6
-        size_y                 = 4
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_qualified_for_benefits_pct[k].id)
+        dashboard_tab_id = 5
+        row              = 2
+        col              = 12
+        size_x           = 6
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_qualified_for_benefits_pct[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },
       {
-        card_id                = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct[k].id)
-        dashboard_tab_id       = 5
-        row                    = 2
-        col                    = 18
-        size_x                 = 6
-        size_y                 = 4
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct[k].id)
+        dashboard_tab_id = 5
+        row              = 2
+        col              = 18
+        size_x           = 6
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },

--- a/dashboards/config_template.tf
+++ b/dashboards/config_template.tf
@@ -33,7 +33,7 @@ locals {
     parameters             = []
     visualization_settings = {}
   }
-  
+
   # Template for scalar scorecards (simple counts)
   tenant_scorecard_config = merge(local.tenant_card_base_config, {
     display = "scalar"
@@ -45,13 +45,13 @@ locals {
       "column_settings" = {}
     }
   })
-  
+
   # Template for table cards with mini bars (flexible)
   tenant_table_card_config = merge(local.tenant_card_base_config, {
     display = "table"
     visualization_settings = {
       "table.column_widths" = []
-      "column_settings" = {}
+      "column_settings"     = {}
     }
   })
 
@@ -61,14 +61,28 @@ locals {
     "decimals"     = 0
   }
 
-  currency_format_0 = { 
-    "number_style" = "currency"
-    "currency" = "USD"
+  currency_format_0 = {
+    "number_style"   = "currency"
+    "currency"       = "USD"
     "currency_style" = "symbol"
-    "decimals" = 0 
-  } 
+    "decimals"       = 0
+  }
 
   show_minibar_true = {
     "show_mini_bar" = true
+  }
+
+  # Per-tenant template-tags for partner field filter (dimension type enables multi-select)
+  partner_template_tags = {
+    for k, v in var.tenants : k => {
+      partner = {
+        id             = "partner_filter"
+        name           = "partner"
+        "display-name" = "Partner"
+        type           = "dimension"
+        dimension      = ["field", tonumber(data.external.partner_field_ids.result[k]), null]
+        "widget-type"  = "string/="
+      }
+    }
   }
 }

--- a/dashboards/config_template.tf
+++ b/dashboards/config_template.tf
@@ -85,12 +85,12 @@ locals {
   # Per-tenant tab selection — order determines tab display order
   tenant_tabs = {
     nc                = ["google_analytics", "all_time", "benefits_needs"]
-    co                = ["google_analytics", "all_time", "last_30_days", "households", "benefits_needs"]
-    tx                = ["google_analytics", "all_time", "benefits_needs"]
-    il                = ["google_analytics", "all_time", "benefits_needs"]
-    ma                = ["google_analytics", "all_time", "benefits_needs"]
-    cesn              = ["google_analytics", "all_time", "benefits_needs"]
-    co_tax_calculator = ["all_time", "benefits_needs"]
+    co                = ["all_time", "last_30_days", "households", "benefits_needs", "google_analytics"]
+    tx                = ["all_time", "last_30_days", "households", "benefits_needs", "google_analytics"]
+    il                = ["all_time", "last_30_days", "households", "benefits_needs", "google_analytics"]
+    ma                = ["all_time", "last_30_days", "households", "benefits_needs", "google_analytics"]
+    cesn              = ["all_time", "last_30_days", "households", "benefits_needs", "google_analytics"]
+    co_tax_calculator = ["all_time", "last_30_days", "households", "benefits_needs"]
   }
 
   # Helper: quick lookup — local.tenant_has_tab["co"]["households"] → true

--- a/dashboards/config_template.tf
+++ b/dashboards/config_template.tf
@@ -72,6 +72,34 @@ locals {
     "show_mini_bar" = true
   }
 
+  # All available dashboard tabs with fixed IDs
+  # IDs are foreign keys used by dashboard_tab_id in layout blocks — do not renumber
+  all_tabs = {
+    google_analytics = { id = 1, name = "Google Analytics" }
+    all_time         = { id = 2, name = "All-Time Performance" }
+    last_30_days     = { id = 3, name = "Last 30 Days Performance" }
+    households       = { id = 4, name = "Households" }
+    benefits_needs   = { id = 5, name = "Benefits & Immediate Needs" }
+  }
+
+  # Per-tenant tab selection — order determines tab display order
+  tenant_tabs = {
+    nc                = ["google_analytics", "all_time", "benefits_needs"]
+    co                = ["google_analytics", "all_time", "last_30_days", "households", "benefits_needs"]
+    tx                = ["google_analytics", "all_time", "benefits_needs"]
+    il                = ["google_analytics", "all_time", "benefits_needs"]
+    ma                = ["google_analytics", "all_time", "benefits_needs"]
+    cesn              = ["google_analytics", "all_time", "benefits_needs"]
+    co_tax_calculator = ["all_time", "benefits_needs"]
+  }
+
+  # Helper: quick lookup — local.tenant_has_tab["co"]["households"] → true
+  tenant_has_tab = {
+    for key, tabs in local.tenant_tabs : key => {
+      for tab_key in keys(local.all_tabs) : tab_key => contains(tabs, tab_key)
+    }
+  }
+
   # Per-tenant template-tags for partner field filter (dimension type enables multi-select)
   partner_template_tags = {
     for k, v in var.tenants : k => {

--- a/dashboards/global_cards.tf
+++ b/dashboards/global_cards.tf
@@ -1,0 +1,764 @@
+# Global card resources for the MFB Analytics Dashboard.
+# Each card mirrors a tenant card but queries the unfiltered global database
+# (metabase_database.postgres) and has no partner filter.
+
+# =============================================================================
+# Helper: strip the Metabase partner template-tag placeholder from SQL files
+# =============================================================================
+locals {
+  # For SQL files: remove the partner filter clause
+  _partner_clause     = " [[AND {{partner}}]]"
+  _partner_clause_alt = "\n    [[AND {{partner}}]]"
+
+  # Base config for global cards (no template-tags, no partner filter)
+  global_card_base_config = {
+    description         = null
+    collection_position = null
+    cache_ttl           = null
+    query_type          = "native"
+    dataset_query = {
+      type = "native"
+    }
+    parameter_mappings     = []
+    parameters             = []
+    visualization_settings = {}
+  }
+
+  global_scorecard_config = merge(local.global_card_base_config, {
+    display = "scalar"
+  })
+
+  global_percentage_card_config = merge(local.global_scorecard_config, {
+    visualization_settings = {
+      "column_settings" = {}
+    }
+  })
+
+  global_table_card_config = merge(local.global_card_base_config, {
+    display = "table"
+    visualization_settings = {
+      "table.column_widths" = []
+      "column_settings"     = {}
+    }
+  })
+
+  global_db_id  = tonumber(metabase_database.postgres.id)
+  global_col_id = tonumber(metabase_collection.global.id)
+}
+
+# =============================================================================
+# Tab 1: All-Time Performance — 9 cards
+# =============================================================================
+
+resource "metabase_card" "global_completed_screeners" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Completed Screeners"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT count(*) AS \"Completed Screeners\" FROM analytics.mart_screener_data WHERE 1=1"
+      }
+    }
+    visualization_settings = { "scalar.field" = "count" }
+  }))
+}
+
+resource "metabase_card" "global_qualified_for_benefits_pct" {
+  json = jsonencode(merge(local.global_percentage_card_config, {
+    name          = "Qualified for Benefits *"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE 1=1"
+      }
+    }
+    visualization_settings = local.benefits_pct_visualization_settings
+  }))
+}
+
+resource "metabase_card" "global_median_annual_benefits" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Median Annual Benefits"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0"
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "global_median_monthly_benefits" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Median Monthly Benefits"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0"
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "global_qualified_for_tax_creds_pct" {
+  json = jsonencode(merge(local.global_percentage_card_config, {
+    name          = "Qualified for Tax Credits *"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT count(*) FILTER (WHERE tax_credits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE 1=1"
+      }
+    }
+    visualization_settings = local.benefits_pct_visualization_settings
+  }))
+}
+
+resource "metabase_card" "global_median_annual_tax_credits" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Median Annual Tax Credits"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0"
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "global_daily_screeners_7d" {
+  json = jsonencode(merge(local.global_card_base_config, {
+    name          = "Daily Screeners (Last 7 Days)"
+    collection_id = local.global_col_id
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '7 days' GROUP BY submission_date ORDER BY submission_date"
+      }
+    }
+    visualization_settings = {
+      "graph.dimensions"        = ["SUBMISSION_DATE"]
+      "graph.metrics"           = ["SCREENERS"]
+      "graph.x_axis.title_text" = "Date"
+      "graph.y_axis.title_text" = "Screeners Completed"
+      "graph.show_values"       = true
+    }
+  }))
+}
+
+resource "metabase_card" "global_top_partners" {
+  json = jsonencode(merge(local.global_table_card_config, {
+    name          = "Which Partners Did The Screeners Come From?"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = replace(
+          replace(
+            templatefile("${path.module}/sql/top_partners.sql", {}),
+            local._partner_clause_alt, ""
+          ),
+          local._partner_clause, ""
+        )
+      }
+    }
+    visualization_settings = merge(local.global_table_card_config.visualization_settings, {
+      "column_settings" = {
+        "[\"name\",\"#\"]" = local.show_minibar_true
+        "[\"name\",\"%\"]" = merge(
+          local.show_minibar_true,
+          local.number_format_percent_0
+        )
+      }
+    })
+  }))
+}
+
+resource "metabase_card" "global_top_counties" {
+  json = jsonencode(merge(local.global_table_card_config, {
+    name          = "Which Counties Did The Screeners Come From?"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = replace(
+          replace(
+            templatefile("${path.module}/sql/top_counties.sql", {}),
+            local._partner_clause_alt, ""
+          ),
+          local._partner_clause, ""
+        )
+      }
+    }
+    visualization_settings = merge(local.global_table_card_config.visualization_settings, {
+      "column_settings" = {
+        "[\"name\",\"#\"]" = local.show_minibar_true
+        "[\"name\",\"%\"]" = merge(
+          local.show_minibar_true,
+          local.number_format_percent_0
+        )
+      }
+    })
+  }))
+}
+
+# =============================================================================
+# Tab 2: Last 30 Days Performance — 9 cards
+# =============================================================================
+
+resource "metabase_card" "global_completed_screeners_30d" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Completed Screeners (30d)"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT count(*) FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+      }
+    }
+    visualization_settings = { "scalar.field" = "count" }
+  }))
+}
+
+resource "metabase_card" "global_qualified_for_benefits_pct_30d" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Qualified for Benefits (30d)"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+      }
+    }
+    visualization_settings = local.benefits_pct_visualization_settings
+  }))
+}
+
+resource "metabase_card" "global_median_annual_benefits_30d" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Median Annual Benefits (30d)"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "global_median_monthly_benefits_30d" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Median Monthly Benefits (30d)"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "global_qualified_for_tax_creds_pct_30d" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Qualified for Tax Credits (30d)"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT count(*) FILTER (WHERE tax_credits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+      }
+    }
+    visualization_settings = local.benefits_pct_visualization_settings
+  }))
+}
+
+resource "metabase_card" "global_median_annual_tax_credits_30d" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Median Annual Tax Credits (30d)"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "global_daily_screeners_30d" {
+  json = jsonencode(merge(local.global_card_base_config, {
+    name          = "Daily Screeners (Last 30 Days)"
+    collection_id = local.global_col_id
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days' GROUP BY submission_date ORDER BY submission_date"
+      }
+    }
+    visualization_settings = {
+      "graph.dimensions"        = ["SUBMISSION_DATE"]
+      "graph.metrics"           = ["SCREENERS"]
+      "graph.x_axis.title_text" = "Date"
+      "graph.y_axis.title_text" = "Screeners Completed"
+      "graph.show_values"       = true
+    }
+  }))
+}
+
+resource "metabase_card" "global_top_partners_30d" {
+  json = jsonencode(merge(local.global_table_card_config, {
+    name          = "Top Partners (Last 30 Days)"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = replace(
+          replace(
+            templatefile("${path.module}/sql/top_partners_30d.sql", {}),
+            local._partner_clause_alt, ""
+          ),
+          local._partner_clause, ""
+        )
+      }
+    }
+    visualization_settings = merge(local.global_table_card_config.visualization_settings, {
+      "column_settings" = {
+        "[\"name\",\"#\"]" = local.show_minibar_true
+        "[\"name\",\"%\"]" = merge(
+          local.show_minibar_true,
+          local.number_format_percent_0
+        )
+      }
+    })
+  }))
+}
+
+resource "metabase_card" "global_top_counties_30d" {
+  json = jsonencode(merge(local.global_table_card_config, {
+    name          = "Top Counties (Last 30 Days)"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = replace(
+          replace(
+            templatefile("${path.module}/sql/top_counties_30d.sql", {}),
+            local._partner_clause_alt, ""
+          ),
+          local._partner_clause, ""
+        )
+      }
+    }
+    visualization_settings = merge(local.global_table_card_config.visualization_settings, {
+      "column_settings" = {
+        "[\"name\",\"#\"]" = local.show_minibar_true
+        "[\"name\",\"%\"]" = merge(
+          local.show_minibar_true,
+          local.number_format_percent_0
+        )
+      }
+    })
+  }))
+}
+
+# =============================================================================
+# Tab 3: Households — 13 cards (reuses global_completed_screeners from Tab 1)
+# =============================================================================
+
+resource "metabase_card" "global_median_household_size" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Household Size (Median)"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY household_size) AS median FROM analytics.mart_screener_data WHERE 1=1"
+      }
+    }
+    visualization_settings = { "scalar.field" = "median" }
+  }))
+}
+
+resource "metabase_card" "global_median_household_assets" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Household Assets (Median)"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY household_assets) AS median FROM analytics.mart_screener_data WHERE 1=1"
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "global_median_annual_income" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Annual Income (Median)"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_income * 12) AS median FROM analytics.mart_screener_data WHERE 1=1"
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "global_median_monthly_income" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Monthly Income (Median)"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_income) AS median FROM analytics.mart_screener_data WHERE 1=1"
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "global_median_monthly_expenses" {
+  json = jsonencode(merge(local.global_scorecard_config, {
+    name          = "Monthly Expenses (Median)"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_expenses) AS median FROM analytics.mart_screener_data WHERE 1=1"
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "global_head_of_household_ages" {
+  json = jsonencode(merge(local.global_card_base_config, {
+    name          = "What are the ages of the heads of household?"
+    collection_id = local.global_col_id
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = replace(
+          replace(
+            templatefile("${path.module}/sql/household_head_ages.sql", {}),
+            local._partner_clause_alt, ""
+          ),
+          local._partner_clause, ""
+        )
+      }
+    }
+    visualization_settings = local.households_pct_bar_chart_settings["Age Group"]
+  }))
+}
+
+resource "metabase_card" "global_household_member_ages" {
+  json = jsonencode(merge(local.global_card_base_config, {
+    name          = "What are the ages of all household members?"
+    collection_id = local.global_col_id
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = replace(
+          replace(
+            templatefile("${path.module}/sql/household_member_ages.sql", {}),
+            local._partner_clause_alt, ""
+          ),
+          local._partner_clause, ""
+        )
+      }
+    }
+    visualization_settings = local.households_pct_bar_chart_settings["Age Group"]
+  }))
+}
+
+resource "metabase_card" "global_household_sizes" {
+  json = jsonencode(merge(local.global_card_base_config, {
+    name          = "What is the breakdown of household sizes?"
+    collection_id = local.global_col_id
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = replace(
+          replace(
+            templatefile("${path.module}/sql/household_sizes.sql", {}),
+            local._partner_clause_alt, ""
+          ),
+          local._partner_clause, ""
+        )
+      }
+    }
+    visualization_settings = local.households_pct_bar_chart_settings["Household Size"]
+  }))
+}
+
+resource "metabase_card" "global_household_languages" {
+  json = jsonencode(merge(local.global_card_base_config, {
+    name          = "What languages are spoken in these households?"
+    collection_id = local.global_col_id
+    display       = "pie"
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = replace(
+          replace(
+            templatefile("${path.module}/sql/household_languages.sql", {}),
+            local._partner_clause_alt, ""
+          ),
+          local._partner_clause, ""
+        )
+      }
+    }
+    visualization_settings = {
+      "pie.dimension" = "Language"
+      "pie.metric"    = "% of Total"
+      "column_settings" = {
+        "[\"name\",\"% of Total\"]" = local.number_format_percent_0
+      }
+    }
+  }))
+}
+
+resource "metabase_card" "global_household_income_distribution" {
+  json = jsonencode(merge(local.global_card_base_config, {
+    name          = "What is the breakdown of household income?"
+    collection_id = local.global_col_id
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = replace(
+          replace(
+            templatefile("${path.module}/sql/household_income_distribution.sql", {}),
+            local._partner_clause_alt, ""
+          ),
+          local._partner_clause, ""
+        )
+      }
+    }
+    visualization_settings = local.households_pct_bar_chart_settings["Income Range"]
+  }))
+}
+
+resource "metabase_card" "global_household_assets_distribution" {
+  json = jsonencode(merge(local.global_card_base_config, {
+    name          = "What is the breakdown of household assets?"
+    collection_id = local.global_col_id
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = replace(
+          replace(
+            templatefile("${path.module}/sql/household_assets_distribution.sql", {}),
+            local._partner_clause_alt, ""
+          ),
+          local._partner_clause, ""
+        )
+      }
+    }
+    visualization_settings = local.households_pct_bar_chart_settings["Asset Range"]
+  }))
+}
+
+resource "metabase_card" "global_income_streams" {
+  json = jsonencode(merge(local.global_table_card_config, {
+    name          = "What income streams do households have?"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = replace(
+          replace(
+            templatefile("${path.module}/sql/income_streams.sql", {}),
+            local._partner_clause_alt, ""
+          ),
+          local._partner_clause, ""
+        )
+      }
+    }
+    visualization_settings = merge(local.global_table_card_config.visualization_settings, {
+      "column_settings" = local.households_table_column_settings
+    })
+  }))
+}
+
+resource "metabase_card" "global_common_expenses" {
+  json = jsonencode(merge(local.global_table_card_config, {
+    name          = "What are the most common expenses?"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = replace(
+          replace(
+            templatefile("${path.module}/sql/common_expenses.sql", {}),
+            local._partner_clause_alt, ""
+          ),
+          local._partner_clause, ""
+        )
+      }
+    }
+    visualization_settings = merge(local.global_table_card_config.visualization_settings, {
+      "column_settings" = local.households_table_column_settings
+    })
+  }))
+}
+
+# =============================================================================
+# Tab 4: Benefits & Immediate Needs — 4 new cards
+# (reuses global_completed_screeners, global_qualified_for_benefits_pct,
+#  global_qualified_for_tax_creds_pct from Tab 1)
+# =============================================================================
+
+resource "metabase_card" "global_already_had_benefits_pct" {
+  json = jsonencode(merge(local.global_percentage_card_config, {
+    name          = "Already Had Benefits"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = "SELECT count(*) FILTER (WHERE has_benefits = 'true')::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data"
+      }
+    }
+    visualization_settings = local.benefits_pct_visualization_settings
+  }))
+}
+
+resource "metabase_card" "global_current_benefits_table" {
+  json = jsonencode(merge(local.global_table_card_config, {
+    name          = "What percentage of users said they already had certain benefits?"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = templatefile("${path.module}/sql/current_benefits.sql", {})
+      }
+    }
+    visualization_settings = merge(local.global_table_card_config.visualization_settings, {
+      "table.column_widths" = [{ "name" = "Benefit Name", "width" = 300 }]
+      "column_settings"     = local.benefits_column_settings
+    })
+  }))
+}
+
+resource "metabase_card" "global_qualified_benefits_table" {
+  json = jsonencode(merge(local.global_table_card_config, {
+    name          = "What percentage of completed screeners qualified for benefits?"
+    description   = "Aggregated benefit eligibility data across all tenants."
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = templatefile("${path.module}/sql/qualified_benefits.sql", {})
+      }
+    }
+    visualization_settings = merge(local.global_table_card_config.visualization_settings, {
+      "table.column_widths" = [{ "name" = "Benefit Name", "width" = 300 }]
+      "column_settings"     = local.benefits_column_settings
+    })
+  }))
+}
+
+resource "metabase_card" "global_immediate_needs_table" {
+  json = jsonencode(merge(local.global_table_card_config, {
+    name          = "What percentage of users sought each immediate need?"
+    collection_id = local.global_col_id
+    dataset_query = {
+      type     = "native"
+      database = local.global_db_id
+      native = {
+        query = templatefile("${path.module}/sql/immediate_needs.sql", {})
+      }
+    }
+    visualization_settings = merge(local.global_table_card_config.visualization_settings, {
+      "table.column_widths" = [{ "name" = "Need Category", "width" = 300 }]
+      "column_settings"     = local.benefits_column_settings
+    })
+  }))
+}

--- a/dashboards/global_cards.tf
+++ b/dashboards/global_cards.tf
@@ -716,7 +716,10 @@ resource "metabase_card" "global_current_benefits_table" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = templatefile("${path.module}/sql/current_benefits.sql", {})
+        query = replace(
+          templatefile("${path.module}/sql/current_benefits.sql", {}),
+          local._partner_clause, ""
+        )
       }
     }
     visualization_settings = merge(local.global_table_card_config.visualization_settings, {
@@ -735,7 +738,10 @@ resource "metabase_card" "global_qualified_benefits_table" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = templatefile("${path.module}/sql/qualified_benefits.sql", {})
+        query = replace(
+          templatefile("${path.module}/sql/qualified_benefits.sql", {}),
+          local._partner_clause, ""
+        )
       }
     }
     visualization_settings = merge(local.global_table_card_config.visualization_settings, {
@@ -753,7 +759,10 @@ resource "metabase_card" "global_immediate_needs_table" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = templatefile("${path.module}/sql/immediate_needs.sql", {})
+        query = replace(
+          templatefile("${path.module}/sql/immediate_needs.sql", {}),
+          local._partner_clause, ""
+        )
       }
     }
     visualization_settings = merge(local.global_table_card_config.visualization_settings, {

--- a/dashboards/global_cards.tf
+++ b/dashboards/global_cards.tf
@@ -158,7 +158,7 @@ resource "metabase_card" "global_daily_screeners_7d" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '7 days' GROUP BY submission_date ORDER BY submission_date"
+        query = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '6 days' GROUP BY submission_date ORDER BY submission_date"
       }
     }
     visualization_settings = {
@@ -241,7 +241,7 @@ resource "metabase_card" "global_completed_screeners_30d" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = "SELECT count(*) FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+        query = "SELECT count(*) FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days'"
       }
     }
     visualization_settings = { "scalar.field" = "count" }
@@ -256,7 +256,7 @@ resource "metabase_card" "global_qualified_for_benefits_pct_30d" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = "SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+        query = "SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days'"
       }
     }
     visualization_settings = local.benefits_pct_visualization_settings
@@ -271,7 +271,7 @@ resource "metabase_card" "global_median_annual_benefits_30d" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '29 days'"
       }
     }
     visualization_settings = {
@@ -289,7 +289,7 @@ resource "metabase_card" "global_median_monthly_benefits_30d" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '29 days'"
       }
     }
     visualization_settings = {
@@ -307,7 +307,7 @@ resource "metabase_card" "global_qualified_for_tax_creds_pct_30d" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = "SELECT count(*) FILTER (WHERE tax_credits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+        query = "SELECT count(*) FILTER (WHERE tax_credits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days'"
       }
     }
     visualization_settings = local.benefits_pct_visualization_settings
@@ -322,7 +322,7 @@ resource "metabase_card" "global_median_annual_tax_credits_30d" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '30 days'"
+        query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '29 days'"
       }
     }
     visualization_settings = {
@@ -341,7 +341,7 @@ resource "metabase_card" "global_daily_screeners_30d" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days' GROUP BY submission_date ORDER BY submission_date"
+        query = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' GROUP BY submission_date ORDER BY submission_date"
       }
     }
     visualization_settings = {

--- a/dashboards/google_analytics.tf
+++ b/dashboards/google_analytics.tf
@@ -1,0 +1,56 @@
+# Cards for "Google Analytics" (Tab 1)
+
+resource "metabase_card" "tenant_monthly_active_users" {
+  for_each = var.bigquery_enabled ? var.tenants : {}
+
+  json = jsonencode({
+    name                   = "What is the monthly active users (MAU) trend?"
+    description            = "Distinct GA4 users per month from BigQuery page view events"
+    collection_id          = tonumber(local.tenant_collection_map[each.key].id)
+    collection_position    = null
+    cache_ttl              = null
+    query_type             = "native"
+    display                = "bar"
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.bigquery[0].id)
+      native = {
+        query = templatefile("${path.module}/sql/monthly_active_users.sql", {
+          state_code = each.key
+        })
+      }
+    }
+    visualization_settings = {
+      "graph.dimensions"        = ["month"]
+      "graph.metrics"           = ["active_users"]
+      "graph.x_axis.title_text" = ""
+      "graph.y_axis.title_text" = ""
+      "graph.show_values"       = true
+      "series_settings" = {
+        "active_users" = { color = "#509EE3" }
+      }
+    }
+    parameter_mappings = []
+    parameters         = []
+  })
+}
+
+# --- Layout ---
+
+locals {
+  tenant_dashboard_ga_layout = {
+    for key, tenant in var.tenants : key => var.bigquery_enabled ? [
+      {
+        card_id                = tonumber(metabase_card.tenant_monthly_active_users[key].id)
+        dashboard_tab_id       = 1
+        row                    = 0
+        col                    = 0
+        size_x                 = 24
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      }
+    ] : []
+  }
+}

--- a/dashboards/google_analytics.tf
+++ b/dashboards/google_analytics.tf
@@ -1,7 +1,25 @@
 # Cards for "Google Analytics" (Tab 1)
 
+locals {
+  # Tenants that have a Google Analytics tab (derived from central tab config)
+  ga_tenants = {
+    for key, tenant in var.tenants : key => tenant
+    if local.tenant_has_tab[key]["google_analytics"]
+  }
+
+  # Map each tenant to the GA state_code(s) used in URL paths
+  tenant_ga_state_codes = {
+    nc   = ["nc"]
+    co   = ["co"]
+    tx   = ["tx"]
+    il   = ["il"]
+    ma   = ["ma"]
+    cesn = ["cesn", "co_energy_calculator"]
+  }
+}
+
 resource "metabase_card" "tenant_monthly_active_users" {
-  for_each = var.bigquery_enabled ? var.tenants : {}
+  for_each = var.bigquery_enabled ? local.ga_tenants : {}
 
   json = jsonencode({
     name                   = "What is the monthly active users (MAU) trend?"
@@ -16,7 +34,7 @@ resource "metabase_card" "tenant_monthly_active_users" {
       database = tonumber(metabase_database.bigquery[0].id)
       native = {
         query = templatefile("${path.module}/sql/monthly_active_users.sql", {
-          state_code = each.key
+          state_codes = join(", ", [for code in lookup(local.tenant_ga_state_codes, each.key, [each.key]) : "'${code}'"])
         })
       }
     }
@@ -39,18 +57,20 @@ resource "metabase_card" "tenant_monthly_active_users" {
 
 locals {
   tenant_dashboard_ga_layout = {
-    for key, tenant in var.tenants : key => var.bigquery_enabled ? [
-      {
-        card_id                = tonumber(metabase_card.tenant_monthly_active_users[key].id)
-        dashboard_tab_id       = 1
-        row                    = 0
-        col                    = 0
-        size_x                 = 24
-        size_y                 = 8
-        parameter_mappings     = []
-        series                 = []
-        visualization_settings = {}
-      }
-    ] : []
+    for key, tenant in var.tenants : key => (
+      var.bigquery_enabled && contains(keys(local.ga_tenants), key) ? [
+        {
+          card_id                = tonumber(metabase_card.tenant_monthly_active_users[key].id)
+          dashboard_tab_id       = 1
+          row                    = 0
+          col                    = 0
+          size_x                 = 24
+          size_y                 = 8
+          parameter_mappings     = []
+          series                 = []
+          visualization_settings = {}
+        }
+      ] : []
+    )
   }
 }

--- a/dashboards/google_analytics.tf
+++ b/dashboards/google_analytics.tf
@@ -22,13 +22,13 @@ resource "metabase_card" "tenant_monthly_active_users" {
   for_each = var.bigquery_enabled ? local.ga_tenants : {}
 
   json = jsonencode({
-    name                   = "What is the monthly active users (MAU) trend?"
-    description            = "Distinct GA4 users per month from BigQuery page view events"
-    collection_id          = tonumber(local.tenant_collection_map[each.key].id)
-    collection_position    = null
-    cache_ttl              = null
-    query_type             = "native"
-    display                = "bar"
+    name                = "What is the monthly active users (MAU) trend?"
+    description         = "Distinct GA4 users per month from BigQuery page view events"
+    collection_id       = tonumber(local.tenant_collection_map[each.key].id)
+    collection_position = null
+    cache_ttl           = null
+    query_type          = "native"
+    display             = "bar"
     dataset_query = {
       type     = "native"
       database = tonumber(metabase_database.bigquery[0].id)

--- a/dashboards/households.tf
+++ b/dashboards/households.tf
@@ -1,0 +1,559 @@
+# Tenant-specific cards for "Households" (Tab 4)
+
+# --- Scorecards ---
+
+resource "metabase_card" "tenant_median_household_size" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Household Size (Median)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY household_size) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = { "scalar.field" = "median" }
+  }))
+}
+
+resource "metabase_card" "tenant_median_household_assets" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Household Assets (Median)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY household_assets) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "tenant_median_annual_income" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Annual Income (Median)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_income * 12) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "tenant_median_monthly_income" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Monthly Income (Median)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_income) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "tenant_median_monthly_expenses" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Monthly Expenses (Median)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_expenses) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+# --- Age distribution bar charts ---
+
+resource "metabase_card" "tenant_head_of_household_ages" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_card_base_config, {
+    name          = "What are the ages of the heads of household?"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = templatefile("${path.module}/sql/household_head_ages.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = local.households_pct_bar_chart_settings["Age Group"]
+  }))
+}
+
+resource "metabase_card" "tenant_household_member_ages" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_card_base_config, {
+    name          = "What are the ages of all household members?"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = templatefile("${path.module}/sql/household_member_ages.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = local.households_pct_bar_chart_settings["Age Group"]
+  }))
+}
+
+# --- Household size + languages ---
+
+resource "metabase_card" "tenant_household_sizes" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_card_base_config, {
+    name          = "What is the breakdown of household sizes?"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = templatefile("${path.module}/sql/household_sizes.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = local.households_pct_bar_chart_settings["Household Size"]
+  }))
+}
+
+resource "metabase_card" "tenant_household_languages" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_card_base_config, {
+    name          = "What languages are spoken in these households?"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    display       = "pie"
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = templatefile("${path.module}/sql/household_languages.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = {
+      "pie.dimension" = "Language"
+      "pie.metric"    = "% of Total"
+      "column_settings" = {
+        "[\"name\",\"% of Total\"]" = local.number_format_percent_0
+      }
+    }
+  }))
+}
+
+# --- Income + assets distribution ---
+
+resource "metabase_card" "tenant_household_income_distribution" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_card_base_config, {
+    name          = "What is the breakdown of household income?"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = templatefile("${path.module}/sql/household_income_distribution.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = local.households_pct_bar_chart_settings["Income Range"]
+  }))
+}
+
+resource "metabase_card" "tenant_household_assets_distribution" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_card_base_config, {
+    name          = "What is the breakdown of household assets?"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = templatefile("${path.module}/sql/household_assets_distribution.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = local.households_pct_bar_chart_settings["Asset Range"]
+  }))
+}
+
+# --- Income streams + expenses tables ---
+
+resource "metabase_card" "tenant_income_streams" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_table_card_config, {
+    name          = "What income streams do households have?"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = templatefile("${path.module}/sql/income_streams.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
+      "column_settings" = local.households_table_column_settings
+    })
+  }))
+}
+
+resource "metabase_card" "tenant_common_expenses" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_table_card_config, {
+    name          = "What are the most common expenses?"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = templatefile("${path.module}/sql/common_expenses.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
+      "column_settings" = local.households_table_column_settings
+    })
+  }))
+}
+
+# --- Shared locals ---
+
+locals {
+  # Reusable bar chart visualization settings for percentage metrics
+  households_pct_bar_chart_settings = {
+    for dim in ["Age Group", "Household Size", "Income Range", "Asset Range"] : dim => {
+      "graph.dimensions"        = [dim]
+      "graph.metrics"           = ["% of Total"]
+      "graph.x_axis.title_text" = dim
+      "graph.y_axis.title_text" = "% of Total"
+      "graph.show_values"       = true
+      "series_settings" = {
+        "% of Total" = { color = "#509EE3" }
+      }
+      "column_settings" = {
+        "[\"name\",\"% of Total\"]" = local.number_format_percent_0
+      }
+    }
+  }
+
+  # Shared column settings for income streams / expenses table cards
+  households_table_column_settings = {
+    "[\"name\",\"% of Screeners\"]" = merge(
+      local.show_minibar_true,
+      local.number_format_percent_0
+    )
+    "[\"name\",\"Median Amount\"]" = merge(
+      local.show_minibar_true,
+      local.currency_format_0
+    )
+  }
+
+  # Dashboard layout for Tab 4: Households (CO only)
+  # Split into data cards and text cards to avoid Terraform tuple type mismatch
+  # in conditional expressions (text cards have different visualization_settings shape)
+
+  tenant_dashboard_households_data_layout = {
+    for k, v in var.tenants : k => [
+      # Row 0: 6 scorecards (reuse completed_screeners + 5 new)
+      {
+        card_id          = tonumber(metabase_card.tenant_completed_screeners[k].id)
+        dashboard_tab_id = 4
+        row              = 0
+        col              = 0
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_completed_screeners[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_median_household_size[k].id)
+        dashboard_tab_id = 4
+        row              = 0
+        col              = 4
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_median_household_size[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_median_household_assets[k].id)
+        dashboard_tab_id = 4
+        row              = 0
+        col              = 8
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_median_household_assets[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_median_annual_income[k].id)
+        dashboard_tab_id = 4
+        row              = 0
+        col              = 12
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_median_annual_income[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_median_monthly_income[k].id)
+        dashboard_tab_id = 4
+        row              = 0
+        col              = 16
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_median_monthly_income[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_median_monthly_expenses[k].id)
+        dashboard_tab_id = 4
+        row              = 0
+        col              = 20
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_median_monthly_expenses[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 4: 2 age distribution charts
+      {
+        card_id          = tonumber(metabase_card.tenant_head_of_household_ages[k].id)
+        dashboard_tab_id = 4
+        row              = 4
+        col              = 6
+        size_x           = 9
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_head_of_household_ages[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_household_member_ages[k].id)
+        dashboard_tab_id = 4
+        row              = 4
+        col              = 15
+        size_x           = 9
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_household_member_ages[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 12: Household sizes + languages
+      {
+        card_id          = tonumber(metabase_card.tenant_household_sizes[k].id)
+        dashboard_tab_id = 4
+        row              = 12
+        col              = 0
+        size_x           = 12
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_household_sizes[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_household_languages[k].id)
+        dashboard_tab_id = 4
+        row              = 12
+        col              = 12
+        size_x           = 12
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_household_languages[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 20: Income/assets distributions
+      {
+        card_id          = tonumber(metabase_card.tenant_household_income_distribution[k].id)
+        dashboard_tab_id = 4
+        row              = 20
+        col              = 6
+        size_x           = 9
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_household_income_distribution[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_household_assets_distribution[k].id)
+        dashboard_tab_id = 4
+        row              = 20
+        col              = 15
+        size_x           = 9
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_household_assets_distribution[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 28: Income streams + expenses tables
+      {
+        card_id          = tonumber(metabase_card.tenant_income_streams[k].id)
+        dashboard_tab_id = 4
+        row              = 28
+        col              = 0
+        size_x           = 12
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_income_streams[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_common_expenses[k].id)
+        dashboard_tab_id = 4
+        row              = 28
+        col              = 12
+        size_x           = 12
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_common_expenses[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+    ]
+  }
+
+  # Text blocks for Tab 4 (separate from data cards to avoid tuple type mismatch)
+  tenant_dashboard_households_text_layout = [
+    {
+      card_id            = null
+      dashboard_tab_id   = 4
+      row                = 4
+      col                = 0
+      size_x             = 6
+      size_y             = 8
+      parameter_mappings = []
+      series             = []
+      visualization_settings = {
+        virtual_card = {
+          name                   = null
+          dataset_query          = {}
+          display                = "text"
+          visualization_settings = {}
+        }
+        text = "### Heads of Household\nThe head of household is the person who filled out the screener. If there is more than one adult in the household, the head of household is the oldest adult.\n\n### Age Groups\nAge bins follow U.S. Census Bureau conventions.\n\n**Head of Household:** 0-18, 19-24, 25-44, 45-64, 65+\n**All Members:** <5, 5-18, 19-24, 25-44, 45-64, 65+"
+      }
+    },
+    {
+      card_id            = null
+      dashboard_tab_id   = 4
+      row                = 20
+      col                = 0
+      size_x             = 6
+      size_y             = 8
+      parameter_mappings = []
+      series             = []
+      visualization_settings = {
+        virtual_card = {
+          name                   = null
+          dataset_query          = {}
+          display                = "text"
+          visualization_settings = {}
+        }
+        text = "### Household Assets & Income\nAssets include savings, checking, and investment accounts.\n\nHouseholds reporting **$50,000+** in assets are likely homeowners (home equity included)."
+      }
+    },
+  ]
+}

--- a/dashboards/last_30_days.tf
+++ b/dashboards/last_30_days.tf
@@ -11,7 +11,7 @@ resource "metabase_card" "tenant_completed_screeners_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT count(*) FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]]"
+        query           = "SELECT count(*) FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]]"
         "template-tags" = local.partner_template_tags[each.key]
       }
     }
@@ -28,7 +28,7 @@ resource "metabase_card" "tenant_qualified_for_benefits_pct_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]]"
+        query           = "SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]]"
         "template-tags" = local.partner_template_tags[each.key]
       }
     }
@@ -45,7 +45,7 @@ resource "metabase_card" "tenant_median_annual_benefits_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]]"
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]]"
         "template-tags" = local.partner_template_tags[each.key]
       }
     }
@@ -65,7 +65,7 @@ resource "metabase_card" "tenant_median_monthly_benefits_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]]"
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]]"
         "template-tags" = local.partner_template_tags[each.key]
       }
     }
@@ -85,7 +85,7 @@ resource "metabase_card" "tenant_qualified_for_tax_creds_pct_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT count(*) FILTER (WHERE tax_credits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]]"
+        query           = "SELECT count(*) FILTER (WHERE tax_credits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]]"
         "template-tags" = local.partner_template_tags[each.key]
       }
     }
@@ -102,7 +102,7 @@ resource "metabase_card" "tenant_median_annual_tax_credits_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]]"
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]]"
         "template-tags" = local.partner_template_tags[each.key]
       }
     }
@@ -125,7 +125,7 @@ resource "metabase_card" "tenant_daily_screeners_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]] GROUP BY submission_date ORDER BY submission_date"
+        query           = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]] GROUP BY submission_date ORDER BY submission_date"
         "template-tags" = local.partner_template_tags[each.key]
       }
     }

--- a/dashboards/last_30_days.tf
+++ b/dashboards/last_30_days.tf
@@ -1,0 +1,339 @@
+# Tenant-specific cards for "Last 30 Days Performance" (Tab 3)
+
+# --- Scorecards ---
+
+resource "metabase_card" "tenant_completed_screeners_30d" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Completed Screeners (30d)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT count(*) FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = { "scalar.field" = "count" }
+  }))
+}
+
+resource "metabase_card" "tenant_qualified_for_benefits_pct_30d" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Qualified for Benefits (30d)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = local.benefits_pct_visualization_settings
+  }))
+}
+
+resource "metabase_card" "tenant_median_annual_benefits_30d" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Median Annual Benefits (30d)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "tenant_median_monthly_benefits_30d" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Median Monthly Benefits (30d)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+resource "metabase_card" "tenant_qualified_for_tax_creds_pct_30d" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Qualified for Tax Credits (30d)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT count(*) FILTER (WHERE tax_credits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = local.benefits_pct_visualization_settings
+  }))
+}
+
+resource "metabase_card" "tenant_median_annual_tax_credits_30d" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Median Annual Tax Credits (30d)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+# --- Bar chart ---
+
+resource "metabase_card" "tenant_daily_screeners_30d" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_card_base_config, {
+    name          = "Daily Screeners (Last 30 Days)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days' [[AND {{partner}}]] GROUP BY submission_date ORDER BY submission_date"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = {
+      "graph.dimensions"        = ["SUBMISSION_DATE"]
+      "graph.metrics"           = ["SCREENERS"]
+      "graph.x_axis.title_text" = "Date"
+      "graph.y_axis.title_text" = "Screeners Completed"
+      "graph.show_values"       = true
+    }
+  }))
+}
+
+# --- Tables ---
+
+resource "metabase_card" "tenant_top_partners_30d" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_table_card_config, {
+    name          = "Top Partners (Last 30 Days)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = templatefile("${path.module}/sql/top_partners_30d.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
+      "column_settings" = {
+        "[\"name\",\"#\"]" = local.show_minibar_true
+        "[\"name\",\"%\"]" = merge(
+          local.show_minibar_true,
+          local.number_format_percent_0
+        )
+      }
+    })
+  }))
+}
+
+resource "metabase_card" "tenant_top_counties_30d" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_table_card_config, {
+    name          = "Top Counties (Last 30 Days)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = templatefile("${path.module}/sql/top_counties_30d.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
+      "column_settings" = {
+        "[\"name\",\"#\"]" = local.show_minibar_true
+        "[\"name\",\"%\"]" = merge(
+          local.show_minibar_true,
+          local.number_format_percent_0
+        )
+      }
+    })
+  }))
+}
+
+# --- Dashboard layout for Tab 3 ---
+
+locals {
+  tenant_dashboard_last_30_days_layout = {
+    for k, v in var.tenants : k => [
+      # Row 0: 6 scorecards
+      {
+        card_id          = tonumber(metabase_card.tenant_completed_screeners_30d[k].id)
+        dashboard_tab_id = 3
+        row              = 0
+        col              = 0
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_completed_screeners_30d[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_qualified_for_benefits_pct_30d[k].id)
+        dashboard_tab_id = 3
+        row              = 0
+        col              = 4
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_qualified_for_benefits_pct_30d[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_median_annual_benefits_30d[k].id)
+        dashboard_tab_id = 3
+        row              = 0
+        col              = 8
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_median_annual_benefits_30d[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_median_monthly_benefits_30d[k].id)
+        dashboard_tab_id = 3
+        row              = 0
+        col              = 12
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_median_monthly_benefits_30d[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct_30d[k].id)
+        dashboard_tab_id = 3
+        row              = 0
+        col              = 16
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct_30d[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_median_annual_tax_credits_30d[k].id)
+        dashboard_tab_id = 3
+        row              = 0
+        col              = 20
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_median_annual_tax_credits_30d[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 4: Bar chart
+      {
+        card_id          = tonumber(metabase_card.tenant_daily_screeners_30d[k].id)
+        dashboard_tab_id = 3
+        row              = 4
+        col              = 0
+        size_x           = 24
+        size_y           = 6
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_daily_screeners_30d[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 10: Two tables side-by-side
+      {
+        card_id          = tonumber(metabase_card.tenant_top_partners_30d[k].id)
+        dashboard_tab_id = 3
+        row              = 10
+        col              = 0
+        size_x           = 12
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_top_partners_30d[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_top_counties_30d[k].id)
+        dashboard_tab_id = 3
+        row              = 10
+        col              = 12
+        size_x           = 12
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_top_counties_30d[k].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+    ]
+  }
+}

--- a/dashboards/main.tf
+++ b/dashboards/main.tf
@@ -13,6 +13,10 @@ terraform {
       source  = "flovouin/metabase"
       version = "~> 0.14"
     }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3"
+    }
     time = {
       source  = "hashicorp/time"
       version = "~> 0.13"

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -489,16 +489,12 @@ resource "metabase_dashboard" "tenant_analytics" {
   )
 
   tabs_json = jsonencode([
-    { id = 1, name = "Google Analytics" },
-    { id = 2, name = "All-Time Performance" },
-    { id = 3, name = "Last 30 Days Performance" },
-    { id = 4, name = "Households" },
-    { id = 5, name = "Benefits & Immediate Needs" }
+    for tab_key in local.tenant_tabs[each.key] : local.all_tabs[tab_key]
   ])
 
   cards_json = jsonencode(concat(
-    # Tab 1: Google Analytics (all tenants, BigQuery)
-    local.tenant_dashboard_ga_layout[each.key],
+    # Tab 1: Google Analytics
+    local.tenant_has_tab[each.key]["google_analytics"] ? local.tenant_dashboard_ga_layout[each.key] : [],
     # Tab 2: All-Time Performance (CO gets full layout; others get just Completed Screeners)
     each.key == "co" ? [
       {
@@ -649,12 +645,12 @@ resource "metabase_dashboard" "tenant_analytics" {
         visualization_settings = {}
       }
     ],
-    # Tab 3: Last 30 Days Performance (CO only)
-    each.key == "co" ? local.tenant_dashboard_last_30_days_layout[each.key] : [],
-    # Tab 4: Households (CO only)
-    each.key == "co" ? local.tenant_dashboard_households_data_layout[each.key] : [],
-    each.key == "co" ? local.tenant_dashboard_households_text_layout : [],
+    # Tab 3: Last 30 Days Performance
+    local.tenant_has_tab[each.key]["last_30_days"] ? local.tenant_dashboard_last_30_days_layout[each.key] : [],
+    # Tab 4: Households
+    local.tenant_has_tab[each.key]["households"] ? local.tenant_dashboard_households_data_layout[each.key] : [],
+    local.tenant_has_tab[each.key]["households"] ? local.tenant_dashboard_households_text_layout : [],
     # Tab 5: Benefits & Immediate Needs
-    local.tenant_dashboard_benefits_needs_layout[each.key]
+    local.tenant_has_tab[each.key]["benefits_needs"] ? local.tenant_dashboard_benefits_needs_layout[each.key] : [],
   ))
 }

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -334,6 +334,32 @@ resource "metabase_card" "tenant_daily_screeners_7d" {
   }))
 }
 
+# Tenant-specific top 10 partners table
+resource "metabase_card" "tenant_top_partners" {
+  for_each = var.tenants
+
+  json = jsonencode(merge(local.tenant_table_card_config, {
+    name          = "Which Partners Did The Screeners Come From?"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query = templatefile("${path.module}/sql/top_partners.sql", {})
+      }
+    }
+    visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
+      "column_settings" = {
+        "[\"name\",\"#\"]" = local.show_minibar_true
+        "[\"name\",\"%\"]" = merge(
+          local.show_minibar_true,
+          local.number_format_percent_0
+        )
+      }
+    })
+  }))
+}
+
 # Dashboard that shows analytics data
 resource "metabase_dashboard" "analytics" {
   name          = "MFB Analytics Dashboard"
@@ -457,6 +483,17 @@ resource "metabase_dashboard" "tenant_analytics" {
         col                    = 0
         size_x                 = 24
         size_y                 = 6
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.tenant_top_partners[each.key].id)
+        dashboard_tab_id       = 2
+        row                    = 10
+        col                    = 0
+        size_x                 = 12
+        size_y                 = 8
         parameter_mappings     = []
         series                 = []
         visualization_settings = {}

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -497,6 +497,8 @@ resource "metabase_dashboard" "tenant_analytics" {
   ])
 
   cards_json = jsonencode(concat(
+    # Tab 1: Google Analytics (all tenants, BigQuery)
+    local.tenant_dashboard_ga_layout[each.key],
     # Tab 2: All-Time Performance (CO gets full layout; others get just Completed Screeners)
     each.key == "co" ? [
       {
@@ -649,6 +651,9 @@ resource "metabase_dashboard" "tenant_analytics" {
     ],
     # Tab 3: Last 30 Days Performance (CO only)
     each.key == "co" ? local.tenant_dashboard_last_30_days_layout[each.key] : [],
+    # Tab 4: Households (CO only)
+    each.key == "co" ? local.tenant_dashboard_households_data_layout[each.key] : [],
+    each.key == "co" ? local.tenant_dashboard_households_text_layout : [],
     # Tab 5: Benefits & Immediate Needs
     local.tenant_dashboard_benefits_needs_layout[each.key]
   ))

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -431,35 +431,539 @@ resource "metabase_card" "tenant_partner_values" {
   }))
 }
 
-# Dashboard that shows analytics data
+# Dashboard that shows analytics data (global aggregate across all tenants)
 resource "metabase_dashboard" "analytics" {
   name          = "MFB Analytics Dashboard"
   collection_id = tonumber(metabase_collection.global.id)
+
+  tabs_json = jsonencode([
+    { id = 1, name = "All-Time Performance" },
+    { id = 2, name = "Last 30 Days Performance" },
+    { id = 3, name = "Households" },
+    { id = 4, name = "Benefits & Immediate Needs" },
+  ])
+
   cards_json = jsonencode(concat(
-    var.bigquery_enabled ? [
+    # -------------------------------------------------------------------------
+    # Tab 1: All-Time Performance
+    # -------------------------------------------------------------------------
+    [
+      # Row 0: 6 scorecards (4 cols each = 24 total)
       {
-        card_id                = tonumber(metabase_card.conversion_funnel[0].id)
+        card_id                = tonumber(metabase_card.global_completed_screeners.id)
+        dashboard_tab_id       = 1
         row                    = 0
+        col                    = 0
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_qualified_for_benefits_pct.id)
+        dashboard_tab_id       = 1
+        row                    = 0
+        col                    = 4
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_median_annual_benefits.id)
+        dashboard_tab_id       = 1
+        row                    = 0
+        col                    = 8
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_median_monthly_benefits.id)
+        dashboard_tab_id       = 1
+        row                    = 0
+        col                    = 12
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_qualified_for_tax_creds_pct.id)
+        dashboard_tab_id       = 1
+        row                    = 0
+        col                    = 16
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_median_annual_tax_credits.id)
+        dashboard_tab_id       = 1
+        row                    = 0
+        col                    = 20
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 4: Daily screeners bar chart (full width)
+      {
+        card_id                = tonumber(metabase_card.global_daily_screeners_7d.id)
+        dashboard_tab_id       = 1
+        row                    = 4
+        col                    = 0
+        size_x                 = 24
+        size_y                 = 6
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 10: Top partners + top counties side-by-side
+      {
+        card_id                = tonumber(metabase_card.global_top_partners.id)
+        dashboard_tab_id       = 1
+        row                    = 10
         col                    = 0
         size_x                 = 12
         size_y                 = 8
         parameter_mappings     = []
         series                 = []
         visualization_settings = {}
-      }
-    ] : [],
+      },
+      {
+        card_id                = tonumber(metabase_card.global_top_counties.id)
+        dashboard_tab_id       = 1
+        row                    = 10
+        col                    = 12
+        size_x                 = 12
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+    ],
+    # -------------------------------------------------------------------------
+    # Tab 2: Last 30 Days Performance
+    # -------------------------------------------------------------------------
+    [
+      # Row 0: 6 scorecards
+      {
+        card_id                = tonumber(metabase_card.global_completed_screeners_30d.id)
+        dashboard_tab_id       = 2
+        row                    = 0
+        col                    = 0
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_qualified_for_benefits_pct_30d.id)
+        dashboard_tab_id       = 2
+        row                    = 0
+        col                    = 4
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_median_annual_benefits_30d.id)
+        dashboard_tab_id       = 2
+        row                    = 0
+        col                    = 8
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_median_monthly_benefits_30d.id)
+        dashboard_tab_id       = 2
+        row                    = 0
+        col                    = 12
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_qualified_for_tax_creds_pct_30d.id)
+        dashboard_tab_id       = 2
+        row                    = 0
+        col                    = 16
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_median_annual_tax_credits_30d.id)
+        dashboard_tab_id       = 2
+        row                    = 0
+        col                    = 20
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 4: Bar chart
+      {
+        card_id                = tonumber(metabase_card.global_daily_screeners_30d.id)
+        dashboard_tab_id       = 2
+        row                    = 4
+        col                    = 0
+        size_x                 = 24
+        size_y                 = 6
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 10: Two tables side-by-side
+      {
+        card_id                = tonumber(metabase_card.global_top_partners_30d.id)
+        dashboard_tab_id       = 2
+        row                    = 10
+        col                    = 0
+        size_x                 = 12
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_top_counties_30d.id)
+        dashboard_tab_id       = 2
+        row                    = 10
+        col                    = 12
+        size_x                 = 12
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+    ],
+    # -------------------------------------------------------------------------
+    # Tab 3: Households
+    # -------------------------------------------------------------------------
+    [
+      # Row 0: 6 scorecards
+      {
+        card_id                = tonumber(metabase_card.global_completed_screeners.id)
+        dashboard_tab_id       = 3
+        row                    = 0
+        col                    = 0
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_median_household_size.id)
+        dashboard_tab_id       = 3
+        row                    = 0
+        col                    = 4
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_median_household_assets.id)
+        dashboard_tab_id       = 3
+        row                    = 0
+        col                    = 8
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_median_annual_income.id)
+        dashboard_tab_id       = 3
+        row                    = 0
+        col                    = 12
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_median_monthly_income.id)
+        dashboard_tab_id       = 3
+        row                    = 0
+        col                    = 16
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_median_monthly_expenses.id)
+        dashboard_tab_id       = 3
+        row                    = 0
+        col                    = 20
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 4: Age distribution charts
+      {
+        card_id                = tonumber(metabase_card.global_head_of_household_ages.id)
+        dashboard_tab_id       = 3
+        row                    = 4
+        col                    = 6
+        size_x                 = 9
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_household_member_ages.id)
+        dashboard_tab_id       = 3
+        row                    = 4
+        col                    = 15
+        size_x                 = 9
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 12: Household sizes + languages
+      {
+        card_id                = tonumber(metabase_card.global_household_sizes.id)
+        dashboard_tab_id       = 3
+        row                    = 12
+        col                    = 0
+        size_x                 = 12
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_household_languages.id)
+        dashboard_tab_id       = 3
+        row                    = 12
+        col                    = 12
+        size_x                 = 12
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 20: Income/assets distributions
+      {
+        card_id                = tonumber(metabase_card.global_household_income_distribution.id)
+        dashboard_tab_id       = 3
+        row                    = 20
+        col                    = 6
+        size_x                 = 9
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_household_assets_distribution.id)
+        dashboard_tab_id       = 3
+        row                    = 20
+        col                    = 15
+        size_x                 = 9
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      # Row 28: Income streams + expenses tables
+      {
+        card_id                = tonumber(metabase_card.global_income_streams.id)
+        dashboard_tab_id       = 3
+        row                    = 28
+        col                    = 0
+        size_x                 = 12
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_common_expenses.id)
+        dashboard_tab_id       = 3
+        row                    = 28
+        col                    = 12
+        size_x                 = 12
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+    ],
+    # Tab 3 text blocks (separate list for type consistency)
     [
       {
-        card_id                = tonumber(metabase_card.screen_count.id)
-        row                    = var.bigquery_enabled ? 8 : 0
+        card_id            = null
+        dashboard_tab_id   = 3
+        row                = 4
+        col                = 0
+        size_x             = 6
+        size_y             = 8
+        parameter_mappings = []
+        series             = []
+        visualization_settings = {
+          virtual_card = {
+            name                   = null
+            dataset_query          = {}
+            display                = "text"
+            visualization_settings = {}
+          }
+          text = "### Heads of Household\nThe head of household is the person who filled out the screener. If there is more than one adult in the household, the head of household is the oldest adult.\n\n### Age Groups\nAge bins follow U.S. Census Bureau conventions.\n\n**Head of Household:** 0-18, 19-24, 25-44, 45-64, 65+\n**All Members:** <5, 5-18, 19-24, 25-44, 45-64, 65+"
+        }
+      },
+      {
+        card_id            = null
+        dashboard_tab_id   = 3
+        row                = 20
+        col                = 0
+        size_x             = 6
+        size_y             = 8
+        parameter_mappings = []
+        series             = []
+        visualization_settings = {
+          virtual_card = {
+            name                   = null
+            dataset_query          = {}
+            display                = "text"
+            visualization_settings = {}
+          }
+          text = "### Household Assets & Income\nAssets include savings, checking, and investment accounts.\n\nHouseholds reporting **$50,000+** in assets are likely homeowners (home equity included)."
+        }
+      },
+    ],
+    # -------------------------------------------------------------------------
+    # Tab 4: Benefits & Immediate Needs
+    # -------------------------------------------------------------------------
+    [
+      {
+        card_id            = null
+        dashboard_tab_id   = 4
+        row                = 0
+        col                = 0
+        size_x             = 24
+        size_y             = 2
+        parameter_mappings = []
+        series             = []
+        visualization_settings = {
+          virtual_card = {
+            name                   = null
+            dataset_query          = {}
+            display                = "text"
+            visualization_settings = {}
+          }
+          text = "# Live | Benefits & Immediate Needs"
+        }
+      },
+      {
+        card_id                = tonumber(metabase_card.global_completed_screeners.id)
+        dashboard_tab_id       = 4
+        row                    = 2
         col                    = 0
         size_x                 = 6
         size_y                 = 4
         parameter_mappings     = []
         series                 = []
         visualization_settings = {}
-      }
-    ]
+      },
+      {
+        card_id                = tonumber(metabase_card.global_already_had_benefits_pct.id)
+        dashboard_tab_id       = 4
+        row                    = 2
+        col                    = 6
+        size_x                 = 6
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_qualified_for_benefits_pct.id)
+        dashboard_tab_id       = 4
+        row                    = 2
+        col                    = 12
+        size_x                 = 6
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_qualified_for_tax_creds_pct.id)
+        dashboard_tab_id       = 4
+        row                    = 2
+        col                    = 18
+        size_x                 = 6
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_current_benefits_table.id)
+        dashboard_tab_id       = 4
+        row                    = 6
+        col                    = 0
+        size_x                 = 12
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_qualified_benefits_table.id)
+        dashboard_tab_id       = 4
+        row                    = 6
+        col                    = 12
+        size_x                 = 12
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.global_immediate_needs_table.id)
+        dashboard_tab_id       = 4
+        row                    = 14
+        col                    = 0
+        size_x                 = 12
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+    ],
   ))
 }
 
@@ -471,7 +975,7 @@ resource "metabase_dashboard" "tenant_analytics" {
   collection_id = tonumber(local.tenant_collection_map[each.key].id)
 
   parameters_json = jsonencode(
-    each.key == "co" ? [
+    local.tenant_has_tab[each.key]["households"] ? [
       {
         id                 = "partner_filter"
         name               = "Partner"
@@ -495,8 +999,8 @@ resource "metabase_dashboard" "tenant_analytics" {
   cards_json = jsonencode(concat(
     # Tab 1: Google Analytics
     local.tenant_has_tab[each.key]["google_analytics"] ? local.tenant_dashboard_ga_layout[each.key] : [],
-    # Tab 2: All-Time Performance (CO gets full layout; others get just Completed Screeners)
-    each.key == "co" ? [
+    # Tab 2: All-Time Performance (full layout with partner filter, or simple screen count)
+    local.tenant_has_tab[each.key]["households"] ? [
       {
         card_id          = tonumber(metabase_card.tenant_completed_screeners[each.key].id)
         dashboard_tab_id = 2
@@ -650,7 +1154,7 @@ resource "metabase_dashboard" "tenant_analytics" {
     # Tab 4: Households
     local.tenant_has_tab[each.key]["households"] ? local.tenant_dashboard_households_data_layout[each.key] : [],
     local.tenant_has_tab[each.key]["households"] ? local.tenant_dashboard_households_text_layout : [],
-    # Tab 5: Benefits & Immediate Needs
-    local.tenant_has_tab[each.key]["benefits_needs"] ? local.tenant_dashboard_benefits_needs_layout[each.key] : [],
+    # Tab 5: Benefits & Immediate Needs (all tenants)
+    local.tenant_dashboard_benefits_needs_layout[each.key],
   ))
 }

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -347,7 +347,7 @@ resource "metabase_card" "tenant_daily_screeners_7d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '7 days' [[AND {{partner}}]] GROUP BY submission_date ORDER BY submission_date"
+        query           = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '6 days' [[AND {{partner}}]] GROUP BY submission_date ORDER BY submission_date"
         "template-tags" = local.partner_template_tags[each.key]
       }
     }

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -647,6 +647,8 @@ resource "metabase_dashboard" "tenant_analytics" {
         visualization_settings = {}
       }
     ],
+    # Tab 3: Last 30 Days Performance (CO only)
+    each.key == "co" ? local.tenant_dashboard_last_30_days_layout[each.key] : [],
     # Tab 5: Benefits & Immediate Needs
     local.tenant_dashboard_benefits_needs_layout[each.key]
   ))

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -112,6 +112,23 @@ data "metabase_table" "tenant_screen_summary_tables" {
   db_id  = tonumber(metabase_database.tenant_postgres[each.key].id)
 }
 
+# Look up Metabase field IDs for the partner column (needed for field filter multi-select).
+# Field IDs are environment-specific; this script queries the Metabase API at plan time.
+data "external" "partner_field_ids" {
+  depends_on = [time_sleep.wait_for_database_sync]
+
+  program = ["python3", "${path.module}/scripts/get_partner_field_ids.py"]
+
+  query = {
+    metabase_url = var.metabase_url
+    username     = var.metabase_admin_email
+    password     = var.metabase_admin_password
+    database_ids = jsonencode({
+      for k, v in var.tenants : k => metabase_database.tenant_postgres[k].id
+    })
+  }
+}
+
 # Global collection for admin-level analytics
 resource "metabase_collection" "global" {
   depends_on = [time_sleep.wait_for_database_sync]
@@ -262,7 +279,10 @@ resource "metabase_card" "tenant_median_annual_benefits" {
     dataset_query = {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
-      native   = { query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0" }
+      native = {
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
     }
     visualization_settings = {
       "scalar.field"    = "median"
@@ -281,7 +301,10 @@ resource "metabase_card" "tenant_median_monthly_benefits" {
     dataset_query = {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
-      native   = { query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0" }
+      native = {
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
     }
     visualization_settings = {
       "scalar.field"    = "median"
@@ -300,7 +323,10 @@ resource "metabase_card" "tenant_median_annual_tax_credits" {
     dataset_query = {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
-      native   = { query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0" }
+      native = {
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0 [[AND {{partner}}]]"
+        "template-tags" = local.partner_template_tags[each.key]
+      }
     }
     visualization_settings = {
       "scalar.field"    = "median"
@@ -321,7 +347,8 @@ resource "metabase_card" "tenant_daily_screeners_7d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '7 days' GROUP BY submission_date ORDER BY submission_date"
+        query           = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '7 days' [[AND {{partner}}]] GROUP BY submission_date ORDER BY submission_date"
+        "template-tags" = local.partner_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -345,7 +372,8 @@ resource "metabase_card" "tenant_top_partners" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query = templatefile("${path.module}/sql/top_partners.sql", {})
+        query           = templatefile("${path.module}/sql/top_partners.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -357,6 +385,49 @@ resource "metabase_card" "tenant_top_partners" {
         )
       }
     })
+  }))
+}
+
+# Tenant-specific top 10 counties table
+resource "metabase_card" "tenant_top_counties" {
+  for_each = var.tenants
+
+  json = jsonencode(merge(local.tenant_table_card_config, {
+    name          = "Which Counties Did The Screeners Come From?"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = templatefile("${path.module}/sql/top_counties.sql", {})
+        "template-tags" = local.partner_template_tags[each.key]
+      }
+    }
+    visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
+      "column_settings" = {
+        "[\"name\",\"#\"]" = local.show_minibar_true
+        "[\"name\",\"%\"]" = merge(
+          local.show_minibar_true,
+          local.number_format_percent_0
+        )
+      }
+    })
+  }))
+}
+
+# Helper card for partner filter dropdown values
+resource "metabase_card" "tenant_partner_values" {
+  for_each = var.tenants
+
+  json = jsonencode(merge(local.tenant_card_base_config, {
+    name          = "Partner Values (Filter Helper)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    display       = "table"
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native   = { query = "SELECT DISTINCT partner FROM analytics.mart_screener_data WHERE partner IS NOT NULL ORDER BY partner" }
+    }
   }))
 }
 
@@ -399,6 +470,24 @@ resource "metabase_dashboard" "tenant_analytics" {
   name          = "${each.value.display_name} Dashboard"
   collection_id = tonumber(local.tenant_collection_map[each.key].id)
 
+  parameters_json = jsonencode(
+    each.key == "co" ? [
+      {
+        id                 = "partner_filter"
+        name               = "Partner"
+        slug               = "partner"
+        type               = "string/="
+        sectionId          = "string"
+        values_query_type  = "list"
+        values_source_type = "card"
+        values_source_config = {
+          card_id     = tonumber(metabase_card.tenant_partner_values[each.key].id)
+          value_field = ["field", "partner", { "base-type" = "type/Text" }]
+        }
+      }
+    ] : []
+  )
+
   tabs_json = jsonencode([
     { id = 1, name = "Google Analytics" },
     { id = 2, name = "All-Time Performance" },
@@ -411,90 +500,137 @@ resource "metabase_dashboard" "tenant_analytics" {
     # Tab 2: All-Time Performance (CO gets full layout; others get just Completed Screeners)
     each.key == "co" ? [
       {
-        card_id                = tonumber(metabase_card.tenant_screen_count[each.key].id)
-        dashboard_tab_id       = 2
-        row                    = 0
-        col                    = 0
-        size_x                 = 4
-        size_y                 = 4
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_completed_screeners[each.key].id)
+        dashboard_tab_id = 2
+        row              = 0
+        col              = 0
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_completed_screeners[each.key].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },
       {
-        card_id                = tonumber(metabase_card.tenant_qualified_for_benefits_pct[each.key].id)
-        dashboard_tab_id       = 2
-        row                    = 0
-        col                    = 4
-        size_x                 = 4
-        size_y                 = 4
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_qualified_for_benefits_pct[each.key].id)
+        dashboard_tab_id = 2
+        row              = 0
+        col              = 4
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_qualified_for_benefits_pct[each.key].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },
       {
-        card_id                = tonumber(metabase_card.tenant_median_annual_benefits[each.key].id)
-        dashboard_tab_id       = 2
-        row                    = 0
-        col                    = 8
-        size_x                 = 4
-        size_y                 = 4
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_median_annual_benefits[each.key].id)
+        dashboard_tab_id = 2
+        row              = 0
+        col              = 8
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_median_annual_benefits[each.key].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },
       {
-        card_id                = tonumber(metabase_card.tenant_median_monthly_benefits[each.key].id)
-        dashboard_tab_id       = 2
-        row                    = 0
-        col                    = 12
-        size_x                 = 4
-        size_y                 = 4
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_median_monthly_benefits[each.key].id)
+        dashboard_tab_id = 2
+        row              = 0
+        col              = 12
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_median_monthly_benefits[each.key].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },
       {
-        card_id                = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct[each.key].id)
-        dashboard_tab_id       = 2
-        row                    = 0
-        col                    = 16
-        size_x                 = 4
-        size_y                 = 4
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct[each.key].id)
+        dashboard_tab_id = 2
+        row              = 0
+        col              = 16
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct[each.key].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },
       {
-        card_id                = tonumber(metabase_card.tenant_median_annual_tax_credits[each.key].id)
-        dashboard_tab_id       = 2
-        row                    = 0
-        col                    = 20
-        size_x                 = 4
-        size_y                 = 4
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_median_annual_tax_credits[each.key].id)
+        dashboard_tab_id = 2
+        row              = 0
+        col              = 20
+        size_x           = 4
+        size_y           = 4
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_median_annual_tax_credits[each.key].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },
       {
-        card_id                = tonumber(metabase_card.tenant_daily_screeners_7d[each.key].id)
-        dashboard_tab_id       = 2
-        row                    = 4
-        col                    = 0
-        size_x                 = 24
-        size_y                 = 6
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_daily_screeners_7d[each.key].id)
+        dashboard_tab_id = 2
+        row              = 4
+        col              = 0
+        size_x           = 24
+        size_y           = 6
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_daily_screeners_7d[each.key].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },
       {
-        card_id                = tonumber(metabase_card.tenant_top_partners[each.key].id)
-        dashboard_tab_id       = 2
-        row                    = 10
-        col                    = 0
-        size_x                 = 12
-        size_y                 = 8
-        parameter_mappings     = []
+        card_id          = tonumber(metabase_card.tenant_top_partners[each.key].id)
+        dashboard_tab_id = 2
+        row              = 10
+        col              = 0
+        size_x           = 12
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_top_partners[each.key].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id          = tonumber(metabase_card.tenant_top_counties[each.key].id)
+        dashboard_tab_id = 2
+        row              = 10
+        col              = 12
+        size_x           = 12
+        size_y           = 8
+        parameter_mappings = [{
+          parameter_id = "partner_filter"
+          card_id      = tonumber(metabase_card.tenant_top_counties[each.key].id)
+          target       = ["dimension", ["template-tag", "partner"]]
+        }]
         series                 = []
         visualization_settings = {}
       },

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -252,6 +252,88 @@ resource "metabase_card" "tenant_screen_count" {
   }))
 }
 
+# Tenant-specific median annual benefits scorecard
+resource "metabase_card" "tenant_median_annual_benefits" {
+  for_each = var.tenants
+
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Median Annual Benefits"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native   = { query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0" }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+# Tenant-specific median monthly benefits scorecard
+resource "metabase_card" "tenant_median_monthly_benefits" {
+  for_each = var.tenants
+
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Median Monthly Benefits"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native   = { query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0" }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+# Tenant-specific median annual tax credits scorecard
+resource "metabase_card" "tenant_median_annual_tax_credits" {
+  for_each = var.tenants
+
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Median Annual Tax Credits"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native   = { query = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0" }
+    }
+    visualization_settings = {
+      "scalar.field"    = "median"
+      "column_settings" = { "[\"name\",\"median\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+# Tenant-specific daily screeners bar chart (last 7 days)
+resource "metabase_card" "tenant_daily_screeners_7d" {
+  for_each = var.tenants
+
+  json = jsonencode(merge(local.tenant_card_base_config, {
+    name          = "Daily Screeners (Last 7 Days)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    display       = "bar"
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '7 days' GROUP BY submission_date ORDER BY submission_date"
+      }
+    }
+    visualization_settings = {
+      "graph.dimensions"        = ["SUBMISSION_DATE"]
+      "graph.metrics"           = ["SCREENERS"]
+      "graph.x_axis.title_text" = "Date"
+      "graph.y_axis.title_text" = "Screeners Completed"
+      "graph.show_values"       = true
+    }
+  }))
+}
+
 # Dashboard that shows analytics data
 resource "metabase_dashboard" "analytics" {
   name          = "MFB Analytics Dashboard"
@@ -259,25 +341,25 @@ resource "metabase_dashboard" "analytics" {
   cards_json = jsonencode(concat(
     var.bigquery_enabled ? [
       {
-        card_id = tonumber(metabase_card.conversion_funnel[0].id)
-        row = 0
-        col = 0
-        size_x = 12
-        size_y = 8
-        parameter_mappings = []
-        series = []
+        card_id                = tonumber(metabase_card.conversion_funnel[0].id)
+        row                    = 0
+        col                    = 0
+        size_x                 = 12
+        size_y                 = 8
+        parameter_mappings     = []
+        series                 = []
         visualization_settings = {}
       }
     ] : [],
     [
       {
-        card_id = tonumber(metabase_card.screen_count.id)
-        row = var.bigquery_enabled ? 8 : 0
-        col = 0
-        size_x = 6
-        size_y = 4
-        parameter_mappings = []
-        series = []
+        card_id                = tonumber(metabase_card.screen_count.id)
+        row                    = var.bigquery_enabled ? 8 : 0
+        col                    = 0
+        size_x                 = 6
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
         visualization_settings = {}
       }
     ]
@@ -300,8 +382,86 @@ resource "metabase_dashboard" "tenant_analytics" {
   ])
 
   cards_json = jsonencode(concat(
-    # Tab 2: All-Time Performance
-    [
+    # Tab 2: All-Time Performance (CO gets full layout; others get just Completed Screeners)
+    each.key == "co" ? [
+      {
+        card_id                = tonumber(metabase_card.tenant_screen_count[each.key].id)
+        dashboard_tab_id       = 2
+        row                    = 0
+        col                    = 0
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.tenant_qualified_for_benefits_pct[each.key].id)
+        dashboard_tab_id       = 2
+        row                    = 0
+        col                    = 4
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.tenant_median_annual_benefits[each.key].id)
+        dashboard_tab_id       = 2
+        row                    = 0
+        col                    = 8
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.tenant_median_monthly_benefits[each.key].id)
+        dashboard_tab_id       = 2
+        row                    = 0
+        col                    = 12
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct[each.key].id)
+        dashboard_tab_id       = 2
+        row                    = 0
+        col                    = 16
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.tenant_median_annual_tax_credits[each.key].id)
+        dashboard_tab_id       = 2
+        row                    = 0
+        col                    = 20
+        size_x                 = 4
+        size_y                 = 4
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      {
+        card_id                = tonumber(metabase_card.tenant_daily_screeners_7d[each.key].id)
+        dashboard_tab_id       = 2
+        row                    = 4
+        col                    = 0
+        size_x                 = 24
+        size_y                 = 6
+        parameter_mappings     = []
+        series                 = []
+        visualization_settings = {}
+      },
+      ] : [
       {
         card_id                = tonumber(metabase_card.tenant_screen_count[each.key].id)
         dashboard_tab_id       = 2

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -433,8 +433,10 @@ resource "metabase_card" "tenant_partner_values" {
 
 # Dashboard that shows analytics data (global aggregate across all tenants)
 resource "metabase_dashboard" "analytics" {
-  name          = "MFB Analytics Dashboard"
-  collection_id = tonumber(metabase_collection.global.id)
+  name                = "MFB Analytics Dashboard"
+  description         = "Aggregate analytics across all white labels"
+  collection_id       = tonumber(metabase_collection.global.id)
+  collection_position = 1
 
   tabs_json = jsonencode([
     { id = 1, name = "All-Time Performance" },
@@ -971,8 +973,10 @@ resource "metabase_dashboard" "analytics" {
 resource "metabase_dashboard" "tenant_analytics" {
   for_each = var.tenants
 
-  name          = "${each.value.display_name} Dashboard"
-  collection_id = tonumber(local.tenant_collection_map[each.key].id)
+  name                = "${each.value.display_name} Dashboard"
+  description         = "Main ${each.value.display_name} white label dashboard"
+  collection_id       = tonumber(local.tenant_collection_map[each.key].id)
+  collection_position = 1
 
   parameters_json = jsonencode(
     local.tenant_has_tab[each.key]["households"] ? [

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -979,7 +979,11 @@ resource "metabase_dashboard" "tenant_analytics" {
   collection_position = 1
 
   parameters_json = jsonencode(
-    local.tenant_has_tab[each.key]["households"] ? [
+    (
+      local.tenant_has_tab[each.key]["households"] ||
+      local.tenant_has_tab[each.key]["last_30_days"] ||
+      local.tenant_has_tab[each.key]["benefits_needs"]
+      ) ? [
       {
         id                 = "partner_filter"
         name               = "Partner"

--- a/dashboards/scripts/get_partner_field_ids.py
+++ b/dashboards/scripts/get_partner_field_ids.py
@@ -52,6 +52,7 @@ def main():
     session_id = get_session(metabase_url, query["username"], query["password"])
 
     result = {}
+    missing = []
     for tenant_key, db_id in database_ids.items():
         field_id = get_field_id(
             metabase_url, session_id, db_id,
@@ -61,6 +62,14 @@ def main():
         )
         if field_id:
             result[tenant_key] = field_id
+        else:
+            missing.append(f"{tenant_key} (db {db_id})")
+
+    if missing:
+        raise SystemExit(
+            "Could not resolve Metabase field IDs for analytics.mart_screener_data.partner: "
+            + ", ".join(missing)
+        )
 
     print(json.dumps(result))
 

--- a/dashboards/scripts/get_partner_field_ids.py
+++ b/dashboards/scripts/get_partner_field_ids.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Look up Metabase field IDs for the partner column across all tenant databases.
+
+Used by Terraform's external data source to dynamically resolve field IDs,
+which differ between environments (local dev, staging, production).
+
+Input (JSON on stdin):
+  {
+    "metabase_url": "http://localhost:3001",
+    "username": "admin@example.com",
+    "password": "secret",
+    "database_ids": "{\"co\": \"3\", \"nc\": \"2\", ...}"
+  }
+
+Output (JSON on stdout):
+  {"co": "5689", "nc": "6329", ...}
+"""
+import json
+import sys
+import urllib.request
+
+
+def get_session(metabase_url, username, password):
+    req = urllib.request.Request(
+        f"{metabase_url}/api/session",
+        data=json.dumps({"username": username, "password": password}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    return json.loads(urllib.request.urlopen(req).read())["id"]
+
+
+def get_field_id(metabase_url, session_id, db_id, table_name, schema, field_name):
+    req = urllib.request.Request(
+        f"{metabase_url}/api/database/{db_id}/metadata?include=tables.fields",
+        headers={"X-Metabase-Session": session_id},
+    )
+    data = json.loads(urllib.request.urlopen(req).read())
+
+    for table in data.get("tables", []):
+        if table.get("name") == table_name and table.get("schema") == schema:
+            for field in table.get("fields", []):
+                if field.get("name") == field_name:
+                    return str(field["id"])
+    return ""
+
+
+def main():
+    query = json.load(sys.stdin)
+    metabase_url = query["metabase_url"]
+    database_ids = json.loads(query["database_ids"])
+
+    session_id = get_session(metabase_url, query["username"], query["password"])
+
+    result = {}
+    for tenant_key, db_id in database_ids.items():
+        field_id = get_field_id(
+            metabase_url, session_id, db_id,
+            table_name="mart_screener_data",
+            schema="analytics",
+            field_name="partner",
+        )
+        if field_id:
+            result[tenant_key] = field_id
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/dashboards/scripts/get_partner_field_ids.py
+++ b/dashboards/scripts/get_partner_field_ids.py
@@ -17,7 +17,20 @@ Output (JSON on stdout):
 """
 import json
 import sys
+import urllib.error
 import urllib.request
+
+REQUEST_TIMEOUT_SECONDS = 15
+
+
+def _load_json(req, context):
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"{context} failed with HTTP {exc.code}: {exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"{context} failed: {exc.reason}") from exc
 
 
 def get_session(metabase_url, username, password):
@@ -26,7 +39,7 @@ def get_session(metabase_url, username, password):
         data=json.dumps({"username": username, "password": password}).encode(),
         headers={"Content-Type": "application/json"},
     )
-    return json.loads(urllib.request.urlopen(req).read())["id"]
+    return _load_json(req, "Creating Metabase session")["id"]
 
 
 def get_field_id(metabase_url, session_id, db_id, table_name, schema, field_name):
@@ -34,7 +47,7 @@ def get_field_id(metabase_url, session_id, db_id, table_name, schema, field_name
         f"{metabase_url}/api/database/{db_id}/metadata?include=tables.fields",
         headers={"X-Metabase-Session": session_id},
     )
-    data = json.loads(urllib.request.urlopen(req).read())
+    data = _load_json(req, f"Loading metadata for database {db_id}")
 
     for table in data.get("tables", []):
         if table.get("name") == table_name and table.get("schema") == schema:

--- a/dashboards/sql/common_expenses.sql
+++ b/dashboards/sql/common_expenses.sql
@@ -1,0 +1,47 @@
+WITH filtered_screeners AS (
+    SELECT id FROM analytics.mart_screener_data
+    WHERE 1=1 [[AND {{partner}}]]
+),
+total AS (
+    SELECT count(*) AS total_screeners FROM filtered_screeners
+),
+monthly_expenses AS (
+    SELECT
+        e.type AS expense_type,
+        e.screener_id,
+        CASE e.frequency
+            WHEN 'monthly' THEN e.amount
+            WHEN 'weekly' THEN e.amount * 4.35
+            WHEN 'biweekly' THEN e.amount * 2.175
+            WHEN 'semimonthly' THEN e.amount * 2
+            WHEN 'yearly' THEN e.amount / 12.0
+            ELSE e.amount
+        END AS monthly_amount
+    FROM analytics.mart_screener_expense e
+    INNER JOIN filtered_screeners f ON e.screener_id = f.id
+    WHERE e.amount > 0
+),
+expense_data AS (
+    SELECT
+        expense_type,
+        count(DISTINCT screener_id) AS screener_count,
+        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_amount) AS median_amount
+    FROM monthly_expenses
+    GROUP BY expense_type
+)
+SELECT
+    CASE expense_type
+        WHEN 'rent' THEN 'Rent'
+        WHEN 'mortgage' THEN 'Mortgage'
+        WHEN 'childCare' THEN 'Child Care'
+        WHEN 'childSupport' THEN 'Child Support'
+        WHEN 'dependentCare' THEN 'Dependent Care'
+        WHEN 'medical' THEN 'Medical'
+        WHEN 'heating' THEN 'Heating'
+        WHEN 'telephone' THEN 'Telephone'
+        ELSE expense_type
+    END AS "Type",
+    screener_count::float / NULLIF(t.total_screeners, 0) AS "% of Screeners",
+    median_amount AS "Median Amount"
+FROM expense_data, total t
+ORDER BY screener_count DESC

--- a/dashboards/sql/current_benefits.sql
+++ b/dashboards/sql/current_benefits.sql
@@ -1,0 +1,10 @@
+WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data)
+SELECT
+    benefit as "Benefit Name",
+    SUM(count) as "# of Screeners",
+    SUM(count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
+FROM analytics.mart_previous_benefits
+CROSS JOIN totals t
+GROUP BY benefit
+HAVING SUM(count) > 0
+ORDER BY SUM(count) DESC

--- a/dashboards/sql/current_benefits.sql
+++ b/dashboards/sql/current_benefits.sql
@@ -1,10 +1,11 @@
-WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data)
+WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]])
 SELECT
     benefit as "Benefit Name",
     SUM(count) as "# of Screeners",
     SUM(count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
 FROM analytics.mart_previous_benefits
 CROSS JOIN totals t
+WHERE 1=1 [[AND {{partner}}]]
 GROUP BY benefit
 HAVING SUM(count) > 0
 ORDER BY SUM(count) DESC

--- a/dashboards/sql/household_assets_distribution.sql
+++ b/dashboards/sql/household_assets_distribution.sql
@@ -1,7 +1,7 @@
 WITH filtered AS (
     SELECT household_assets
     FROM analytics.mart_screener_data
-    WHERE 1=1 [[AND {{partner}}]]
+    WHERE household_assets IS NOT NULL [[AND {{partner}}]]
 ),
 total AS (
     SELECT count(*) AS n FROM filtered

--- a/dashboards/sql/household_assets_distribution.sql
+++ b/dashboards/sql/household_assets_distribution.sql
@@ -1,0 +1,33 @@
+WITH filtered AS (
+    SELECT household_assets
+    FROM analytics.mart_screener_data
+    WHERE 1=1 [[AND {{partner}}]]
+),
+total AS (
+    SELECT count(*) AS n FROM filtered
+),
+asset_bins AS (
+    SELECT
+        CASE
+            WHEN household_assets < 1000 THEN '$0-1K'
+            WHEN household_assets < 2000 THEN '$1-2K'
+            WHEN household_assets < 5000 THEN '$2-5K'
+            WHEN household_assets < 10000 THEN '$5-10K'
+            WHEN household_assets < 50000 THEN '$10-50K'
+            ELSE '$50K+'
+        END AS asset_range,
+        CASE
+            WHEN household_assets < 1000 THEN 1
+            WHEN household_assets < 2000 THEN 2
+            WHEN household_assets < 5000 THEN 3
+            WHEN household_assets < 10000 THEN 4
+            WHEN household_assets < 50000 THEN 5
+            ELSE 6
+        END AS sort_order
+    FROM filtered
+)
+SELECT asset_range AS "Asset Range",
+       count(*)::float / NULLIF(max(t.n), 0) AS "% of Total"
+FROM asset_bins, total t
+GROUP BY asset_range, sort_order
+ORDER BY sort_order

--- a/dashboards/sql/household_head_ages.sql
+++ b/dashboards/sql/household_head_ages.sql
@@ -1,0 +1,32 @@
+WITH filtered AS (
+    SELECT age FROM analytics.mart_householdmembers
+    WHERE relationship = 'headOfHousehold'
+    [[AND {{partner}}]]
+),
+total AS (
+    SELECT count(*) AS n FROM filtered WHERE age IS NOT NULL
+),
+age_bins AS (
+    SELECT
+        CASE
+            WHEN age BETWEEN 0 AND 18 THEN '0-18'
+            WHEN age BETWEEN 19 AND 24 THEN '19-24'
+            WHEN age BETWEEN 25 AND 44 THEN '25-44'
+            WHEN age BETWEEN 45 AND 64 THEN '45-64'
+            WHEN age >= 65 THEN '65+'
+        END AS age_group,
+        CASE
+            WHEN age BETWEEN 0 AND 18 THEN 1
+            WHEN age BETWEEN 19 AND 24 THEN 2
+            WHEN age BETWEEN 25 AND 44 THEN 3
+            WHEN age BETWEEN 45 AND 64 THEN 4
+            WHEN age >= 65 THEN 5
+        END AS sort_order
+    FROM filtered
+    WHERE age IS NOT NULL
+)
+SELECT age_group AS "Age Group",
+       count(*)::float / NULLIF(max(t.n), 0) AS "% of Total"
+FROM age_bins, total t
+GROUP BY age_group, sort_order
+ORDER BY sort_order

--- a/dashboards/sql/household_income_distribution.sql
+++ b/dashboards/sql/household_income_distribution.sql
@@ -1,7 +1,7 @@
 WITH filtered AS (
     SELECT monthly_income * 12 AS annual_income
     FROM analytics.mart_screener_data
-    WHERE 1=1 [[AND {{partner}}]]
+    WHERE monthly_income IS NOT NULL [[AND {{partner}}]]
 ),
 total AS (
     SELECT count(*) AS n FROM filtered

--- a/dashboards/sql/household_income_distribution.sql
+++ b/dashboards/sql/household_income_distribution.sql
@@ -1,0 +1,35 @@
+WITH filtered AS (
+    SELECT monthly_income * 12 AS annual_income
+    FROM analytics.mart_screener_data
+    WHERE 1=1 [[AND {{partner}}]]
+),
+total AS (
+    SELECT count(*) AS n FROM filtered
+),
+income_bins AS (
+    SELECT
+        CASE
+            WHEN annual_income < 15000 THEN '$0-15K'
+            WHEN annual_income < 30000 THEN '$15-30K'
+            WHEN annual_income < 45000 THEN '$30-45K'
+            WHEN annual_income < 60000 THEN '$45-60K'
+            WHEN annual_income < 75000 THEN '$60-75K'
+            WHEN annual_income < 100000 THEN '$75-100K'
+            ELSE '$100K+'
+        END AS income_range,
+        CASE
+            WHEN annual_income < 15000 THEN 1
+            WHEN annual_income < 30000 THEN 2
+            WHEN annual_income < 45000 THEN 3
+            WHEN annual_income < 60000 THEN 4
+            WHEN annual_income < 75000 THEN 5
+            WHEN annual_income < 100000 THEN 6
+            ELSE 7
+        END AS sort_order
+    FROM filtered
+)
+SELECT income_range AS "Income Range",
+       count(*)::float / NULLIF(max(t.n), 0) AS "% of Total"
+FROM income_bins, total t
+GROUP BY income_range, sort_order
+ORDER BY sort_order

--- a/dashboards/sql/household_languages.sql
+++ b/dashboards/sql/household_languages.sql
@@ -1,0 +1,14 @@
+WITH filtered AS (
+    SELECT request_language_code
+    FROM analytics.mart_screener_data
+    WHERE 1=1 [[AND {{partner}}]]
+),
+total AS (
+    SELECT count(*) AS n FROM filtered
+)
+SELECT
+    request_language_code AS "Language",
+    count(*)::float / NULLIF(max(t.n), 0) AS "% of Total"
+FROM filtered, total t
+GROUP BY request_language_code
+ORDER BY count(*) DESC

--- a/dashboards/sql/household_member_ages.sql
+++ b/dashboards/sql/household_member_ages.sql
@@ -1,0 +1,34 @@
+WITH filtered AS (
+    SELECT age FROM analytics.mart_householdmembers
+    WHERE 1=1
+    [[AND {{partner}}]]
+),
+total AS (
+    SELECT count(*) AS n FROM filtered WHERE age IS NOT NULL
+),
+age_bins AS (
+    SELECT
+        CASE
+            WHEN age < 5 THEN '<5'
+            WHEN age BETWEEN 5 AND 18 THEN '5-18'
+            WHEN age BETWEEN 19 AND 24 THEN '19-24'
+            WHEN age BETWEEN 25 AND 44 THEN '25-44'
+            WHEN age BETWEEN 45 AND 64 THEN '45-64'
+            WHEN age >= 65 THEN '65+'
+        END AS age_group,
+        CASE
+            WHEN age < 5 THEN 1
+            WHEN age BETWEEN 5 AND 18 THEN 2
+            WHEN age BETWEEN 19 AND 24 THEN 3
+            WHEN age BETWEEN 25 AND 44 THEN 4
+            WHEN age BETWEEN 45 AND 64 THEN 5
+            WHEN age >= 65 THEN 6
+        END AS sort_order
+    FROM filtered
+    WHERE age IS NOT NULL
+)
+SELECT age_group AS "Age Group",
+       count(*)::float / NULLIF(max(t.n), 0) AS "% of Total"
+FROM age_bins, total t
+GROUP BY age_group, sort_order
+ORDER BY sort_order

--- a/dashboards/sql/household_sizes.sql
+++ b/dashboards/sql/household_sizes.sql
@@ -1,0 +1,20 @@
+WITH filtered AS (
+    SELECT household_size
+    FROM analytics.mart_screener_data
+    WHERE 1=1 [[AND {{partner}}]]
+),
+total AS (
+    SELECT count(*) AS n FROM filtered
+)
+SELECT
+    CASE
+        WHEN household_size >= 8 THEN '8+'
+        ELSE household_size::text
+    END AS "Household Size",
+    count(*)::float / NULLIF(max(t.n), 0) AS "% of Total"
+FROM filtered, total t
+GROUP BY
+    CASE WHEN household_size >= 8 THEN '8+' ELSE household_size::text END,
+    CASE WHEN household_size >= 8 THEN 8 ELSE household_size END
+ORDER BY
+    CASE WHEN household_size >= 8 THEN 8 ELSE household_size END

--- a/dashboards/sql/immediate_needs.sql
+++ b/dashboards/sql/immediate_needs.sql
@@ -1,9 +1,10 @@
-WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data)
+WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]])
 SELECT
     benefit as "Need Category",
     SUM(count) as "# of Screeners",
     SUM(count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
 FROM analytics.mart_immediate_needs
 CROSS JOIN totals t
+WHERE 1=1 [[AND {{partner}}]]
 GROUP BY benefit
 ORDER BY SUM(count) DESC

--- a/dashboards/sql/immediate_needs.sql
+++ b/dashboards/sql/immediate_needs.sql
@@ -1,0 +1,9 @@
+WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data)
+SELECT
+    benefit as "Need Category",
+    SUM(count) as "# of Screeners",
+    SUM(count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
+FROM analytics.mart_immediate_needs
+CROSS JOIN totals t
+GROUP BY benefit
+ORDER BY SUM(count) DESC

--- a/dashboards/sql/income_streams.sql
+++ b/dashboards/sql/income_streams.sql
@@ -1,0 +1,58 @@
+WITH filtered_screeners AS (
+    SELECT id FROM analytics.mart_screener_data
+    WHERE 1=1 [[AND {{partner}}]]
+),
+total AS (
+    SELECT count(*) AS total_screeners FROM filtered_screeners
+),
+monthly_income AS (
+    SELECT
+        i.type AS income_type,
+        i.screener_id,
+        CASE i.frequency
+            WHEN 'monthly' THEN i.amount
+            WHEN 'weekly' THEN i.amount * 4.35
+            WHEN 'biweekly' THEN i.amount * 2.175
+            WHEN 'semimonthly' THEN i.amount * 2
+            WHEN 'yearly' THEN i.amount / 12.0
+            WHEN 'hourly' THEN i.amount * COALESCE(i.hours_worked, 0) * 4.35
+            ELSE i.amount
+        END AS monthly_amount
+    FROM analytics.mart_income i
+    INNER JOIN filtered_screeners f ON i.screener_id = f.id
+    WHERE i.amount > 0
+),
+income_data AS (
+    SELECT
+        income_type,
+        count(DISTINCT screener_id) AS screener_count,
+        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_amount) AS median_amount
+    FROM monthly_income
+    GROUP BY income_type
+)
+SELECT
+    CASE income_type
+        WHEN 'wages' THEN 'Wages'
+        WHEN 'selfEmployment' THEN 'Self Employment'
+        WHEN 'sSDisability' THEN 'SS Disability'
+        WHEN 'sSRetirement' THEN 'SS Retirement'
+        WHEN 'SSI' THEN 'SSI'
+        WHEN 'sSDependent' THEN 'SS Dependent'
+        WHEN 'sSSurvivor' THEN 'SS Survivor'
+        WHEN 'unemployment' THEN 'Unemployment'
+        WHEN 'pension' THEN 'Pension'
+        WHEN 'investmentIncome' THEN 'Investment Income'
+        WHEN 'rental' THEN 'Rental'
+        WHEN 'alimony' THEN 'Alimony'
+        WHEN 'childSupport' THEN 'Child Support'
+        WHEN 'DIVABenefits' THEN 'VA Disability'
+        WHEN 'workersComp' THEN 'Workers Comp'
+        WHEN 'giftedIncome' THEN 'Gifted Income'
+        WHEN 'boarder' THEN 'Boarder'
+        WHEN 'cOWorks' THEN 'CO Works'
+        ELSE income_type
+    END AS "Type",
+    screener_count::float / NULLIF(t.total_screeners, 0) AS "% of Screeners",
+    median_amount AS "Median Amount"
+FROM income_data, total t
+ORDER BY screener_count DESC

--- a/dashboards/sql/monthly_active_users.sql
+++ b/dashboards/sql/monthly_active_users.sql
@@ -2,6 +2,6 @@ SELECT
     DATE_TRUNC(event_date_parsed, MONTH) AS month,
     COUNT(DISTINCT user_pseudo_id) AS active_users
 FROM `analytics_internal`.`int_ga4_page_views`
-WHERE state_code = '${state_code}'
+WHERE state_code IN (${state_codes})
 GROUP BY month
 ORDER BY month

--- a/dashboards/sql/monthly_active_users.sql
+++ b/dashboards/sql/monthly_active_users.sql
@@ -1,0 +1,7 @@
+SELECT
+    DATE_TRUNC(event_date_parsed, MONTH) AS month,
+    COUNT(DISTINCT user_pseudo_id) AS active_users
+FROM `analytics_internal`.`int_ga4_page_views`
+WHERE state_code = '${state_code}'
+GROUP BY month
+ORDER BY month

--- a/dashboards/sql/qualified_benefits.sql
+++ b/dashboards/sql/qualified_benefits.sql
@@ -1,5 +1,5 @@
 WITH totals AS (
-    SELECT count(*) as total_count FROM analytics.mart_screener_data
+    SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]
 )
 SELECT
     qb.benefit as "Benefit Name",
@@ -7,5 +7,6 @@ SELECT
     SUM(qb.count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
 FROM analytics.mart_qualified_benefits qb
 CROSS JOIN totals t
+WHERE 1=1 [[AND {{partner}}]]
 GROUP BY qb.benefit
 ORDER BY SUM(qb.count) DESC

--- a/dashboards/sql/qualified_benefits.sql
+++ b/dashboards/sql/qualified_benefits.sql
@@ -1,0 +1,11 @@
+WITH totals AS (
+    SELECT count(*) as total_count FROM analytics.mart_screener_data
+)
+SELECT
+    qb.benefit as "Benefit Name",
+    SUM(qb.count) as "# of Screeners",
+    SUM(qb.count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
+FROM analytics.mart_qualified_benefits qb
+CROSS JOIN totals t
+GROUP BY qb.benefit
+ORDER BY SUM(qb.count) DESC

--- a/dashboards/sql/top_counties.sql
+++ b/dashboards/sql/top_counties.sql
@@ -2,23 +2,24 @@ WITH filtered AS (
     SELECT * FROM analytics.mart_screener_data
     WHERE 1=1 [[AND {{partner}}]]
 ),
-ranked AS (
-    SELECT partner, count(*) AS screeners
+county_counts AS (
+    SELECT county, count(*) AS screeners
     FROM filtered
-    GROUP BY partner
+    WHERE county IS NOT NULL AND county <> ''
+    GROUP BY county
     ORDER BY screeners DESC
     LIMIT 10
 ),
 total_screeners AS (
     SELECT count(*) AS total FROM filtered
 )
-SELECT "Top 10 Partners", "#", "%" FROM (
-    SELECT 0 AS sort_order, partner AS "Top 10 Partners", screeners AS "#",
+SELECT "Top 10 Counties", "#", "%" FROM (
+    SELECT 0 AS sort_order, county AS "Top 10 Counties", screeners AS "#",
            screeners::float / NULLIF(t.total, 0) AS "%"
-    FROM ranked, total_screeners t
+    FROM county_counts, total_screeners t
     UNION ALL
     SELECT 1, 'Total', sum(screeners),
            sum(screeners)::float / NULLIF(max(t.total), 0)
-    FROM ranked, total_screeners t
+    FROM county_counts, total_screeners t
 ) combined
 ORDER BY sort_order, "#" DESC

--- a/dashboards/sql/top_counties.sql
+++ b/dashboards/sql/top_counties.sql
@@ -18,8 +18,8 @@ SELECT "Top 10 Counties", "#", "%" FROM (
            screeners::float / NULLIF(t.total, 0) AS "%"
     FROM county_counts, total_screeners t
     UNION ALL
-    SELECT 1, 'Total', sum(screeners),
-           sum(screeners)::float / NULLIF(max(t.total), 0)
-    FROM county_counts, total_screeners t
+    SELECT 1 AS sort_order, 'Total' AS "Top 10 Counties", t.total AS "#",
+           CASE WHEN t.total = 0 THEN NULL ELSE 1::float END AS "%"
+    FROM total_screeners t
 ) combined
 ORDER BY sort_order, "#" DESC

--- a/dashboards/sql/top_counties_30d.sql
+++ b/dashboards/sql/top_counties_30d.sql
@@ -1,6 +1,6 @@
 WITH filtered AS (
     SELECT * FROM analytics.mart_screener_data
-    WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days'
+    WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days'
     [[AND {{partner}}]]
 ),
 county_counts AS (
@@ -19,8 +19,8 @@ SELECT "Top 10 Counties", "#", "%" FROM (
            screeners::float / NULLIF(t.total, 0) AS "%"
     FROM county_counts, total_screeners t
     UNION ALL
-    SELECT 1, 'Total', sum(screeners),
-           sum(screeners)::float / NULLIF(max(t.total), 0)
-    FROM county_counts, total_screeners t
+    SELECT 1 AS sort_order, 'Total' AS "Top 10 Counties", t.total AS "#",
+           CASE WHEN t.total = 0 THEN NULL ELSE 1::float END AS "%"
+    FROM total_screeners t
 ) combined
 ORDER BY sort_order, "#" DESC

--- a/dashboards/sql/top_counties_30d.sql
+++ b/dashboards/sql/top_counties_30d.sql
@@ -1,0 +1,26 @@
+WITH filtered AS (
+    SELECT * FROM analytics.mart_screener_data
+    WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days'
+    [[AND {{partner}}]]
+),
+county_counts AS (
+    SELECT county, count(*) AS screeners
+    FROM filtered
+    WHERE county IS NOT NULL AND county <> ''
+    GROUP BY county
+    ORDER BY screeners DESC
+    LIMIT 10
+),
+total_screeners AS (
+    SELECT count(*) AS total FROM filtered
+)
+SELECT "Top 10 Counties", "#", "%" FROM (
+    SELECT 0 AS sort_order, county AS "Top 10 Counties", screeners AS "#",
+           screeners::float / NULLIF(t.total, 0) AS "%"
+    FROM county_counts, total_screeners t
+    UNION ALL
+    SELECT 1, 'Total', sum(screeners),
+           sum(screeners)::float / NULLIF(max(t.total), 0)
+    FROM county_counts, total_screeners t
+) combined
+ORDER BY sort_order, "#" DESC

--- a/dashboards/sql/top_partners.sql
+++ b/dashboards/sql/top_partners.sql
@@ -1,0 +1,20 @@
+WITH ranked AS (
+    SELECT partner, count(*) AS screeners
+    FROM analytics.mart_screener_data
+    GROUP BY partner
+    ORDER BY screeners DESC
+    LIMIT 10
+),
+total_screeners AS (
+    SELECT count(*) AS total FROM analytics.mart_screener_data
+)
+SELECT "Top 10 Partners", "#", "%" FROM (
+    SELECT 0 AS sort_order, partner AS "Top 10 Partners", screeners AS "#",
+           screeners::float / NULLIF(t.total, 0) AS "%"
+    FROM ranked, total_screeners t
+    UNION ALL
+    SELECT 1, 'Total', sum(screeners),
+           sum(screeners)::float / NULLIF(max(t.total), 0)
+    FROM ranked, total_screeners t
+) combined
+ORDER BY sort_order, "#" DESC

--- a/dashboards/sql/top_partners.sql
+++ b/dashboards/sql/top_partners.sql
@@ -17,8 +17,8 @@ SELECT "Top 10 Partners", "#", "%" FROM (
            screeners::float / NULLIF(t.total, 0) AS "%"
     FROM ranked, total_screeners t
     UNION ALL
-    SELECT 1, 'Total', sum(screeners),
-           sum(screeners)::float / NULLIF(max(t.total), 0)
-    FROM ranked, total_screeners t
+    SELECT 1 AS sort_order, 'Total' AS "Top 10 Partners", t.total AS "#",
+           CASE WHEN t.total = 0 THEN NULL ELSE 1::float END AS "%"
+    FROM total_screeners t
 ) combined
 ORDER BY sort_order, "#" DESC

--- a/dashboards/sql/top_partners_30d.sql
+++ b/dashboards/sql/top_partners_30d.sql
@@ -1,6 +1,6 @@
 WITH filtered AS (
     SELECT * FROM analytics.mart_screener_data
-    WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days'
+    WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days'
     [[AND {{partner}}]]
 ),
 ranked AS (
@@ -18,8 +18,8 @@ SELECT "Top 10 Partners", "#", "%" FROM (
            screeners::float / NULLIF(t.total, 0) AS "%"
     FROM ranked, total_screeners t
     UNION ALL
-    SELECT 1, 'Total', sum(screeners),
-           sum(screeners)::float / NULLIF(max(t.total), 0)
-    FROM ranked, total_screeners t
+    SELECT 1 AS sort_order, 'Total' AS "Top 10 Partners", t.total AS "#",
+           CASE WHEN t.total = 0 THEN NULL ELSE 1::float END AS "%"
+    FROM total_screeners t
 ) combined
 ORDER BY sort_order, "#" DESC

--- a/dashboards/sql/top_partners_30d.sql
+++ b/dashboards/sql/top_partners_30d.sql
@@ -1,0 +1,25 @@
+WITH filtered AS (
+    SELECT * FROM analytics.mart_screener_data
+    WHERE submission_date >= CURRENT_DATE - INTERVAL '30 days'
+    [[AND {{partner}}]]
+),
+ranked AS (
+    SELECT partner, count(*) AS screeners
+    FROM filtered
+    GROUP BY partner
+    ORDER BY screeners DESC
+    LIMIT 10
+),
+total_screeners AS (
+    SELECT count(*) AS total FROM filtered
+)
+SELECT "Top 10 Partners", "#", "%" FROM (
+    SELECT 0 AS sort_order, partner AS "Top 10 Partners", screeners AS "#",
+           screeners::float / NULLIF(t.total, 0) AS "%"
+    FROM ranked, total_screeners t
+    UNION ALL
+    SELECT 1, 'Total', sum(screeners),
+           sum(screeners)::float / NULLIF(max(t.total), 0)
+    FROM ranked, total_screeners t
+) combined
+ORDER BY sort_order, "#" DESC

--- a/dbt/models/bigquery/intermediate/int_ga4_page_views.sql
+++ b/dbt/models/bigquery/intermediate/int_ga4_page_views.sql
@@ -28,7 +28,7 @@ SELECT
     -- Derived page fields (business logic)
     regexp_extract(page_location, r'[^/]+://[^/]+(/[^?]*)') AS page_path,
     regexp_extract(page_location, r'[^/]+://([^/]+)') AS page_hostname,
-    regexp_extract(page_location, r'^[^/]+://[^/]+/([a-z]{2})/', 1) AS state_code
+    regexp_extract(page_location, r'^[^/]+://[^/]+/([a-z][a-z0-9_]+)/', 1) AS state_code
 
 FROM {{ ref('stg_ga_page_views') }}
 WHERE page_location IS NOT NULL

--- a/dbt/models/postgres/intermediate/int_complete_screener_data.sql
+++ b/dbt/models/postgres/intermediate/int_complete_screener_data.sql
@@ -281,7 +281,7 @@ WITH base_table_1 AS (
                         WHEN trim(ss.referral_source) <> trim(ss.referrer_code)
                             THEN
                                 CASE
-                                    WHEN drc2.referrer_code IS NOT NULL THEN concat(drc1.partner, ', ', drc2.partner)
+                                    WHEN drc2.referrer_code IS NOT NULL THEN concat_ws(', ', drc1.partner, drc2.partner)
                                     WHEN drc1.referrer_code IS NOT NULL THEN drc1.partner
                                     ELSE 'Other'
                                 END


### PR DESCRIPTION
## Summary

Builds out initial full Metabase dashboards for all tenants and a global aggregate dashboard, replacing the previous CO-only layout. Previously only Colorado had scorecards, charts, and tables — other tenants just had a basic screen count card. Now every tenant gets the full dashboard experience. Didn't include NC because I didn't want to interfere with CTD's plans but feel free to leverage anything included in this PR.

[Loom Recording](https://www.loom.com/share/b245999629ed424db084cb26dde5a29c) to visualize the changes

- **Expand all tenant dashboards** from a single screen-count card to 5 tabs: All-Time Performance (scorecards, daily chart, top partners/counties), Last 30 Days, Households (demographics, income/assets distributions), Benefits & Immediate Needs, and Google Analytics
- **Add global analytics dashboard** with 30+ cards querying the unfiltered database, matching the tenant layout across 4 tabs (no GA tab since that's per-tenant BigQuery data)
- **Add partner filter** with multi-select dropdown on all tenant dashboards (previously CO-only), powered by Metabase field filters with dynamically resolved field IDs
- **Centralize tab configuration** into a single `tenant_tabs` registry in `config_template.tf` — adding/removing tabs per tenant is now a one-line change
- **Extract SQL into template files** — long CTE queries moved from inline HCL to `sql/` directory, loaded via `templatefile()`
- **Add Google Analytics MAU chart** using BigQuery, with support for multi-code tenants (e.g. CESN maps to both `cesn` and `co_energy_calculator` URL paths)
- **Pin dashboards to top of collections** with `collection_position = 1` and add descriptive subtitles
- **Fix dbt partner name** — switch `concat` to `concat_ws` to eliminate leading commas

### New files
| File | Purpose |
|------|---------|
| `dashboards/global_cards.tf` | 30+ global card resources (no partner filter, global DB) |
| `dashboards/households.tf` | 13 Households tab card resources |
| `dashboards/last_30_days.tf` | 9 Last 30 Days tab card resources |
| `dashboards/google_analytics.tf` | Monthly Active Users chart from BigQuery |
| `dashboards/scripts/get_partner_field_ids.py` | Resolves Metabase field IDs per environment |
| `dashboards/sql/*.sql` | 16 SQL template files for complex queries |

### Key architectural decisions
- Global cards strip `[[AND {{partner}}]]` from SQL via `replace(templatefile(...))` rather than duplicating SQL files
- Partner filter uses Metabase "dimension" template tags (not basic text) to enable multi-select checkboxes
- Tab visibility is driven by `tenant_tabs` map — dashboard layout conditionals read from this single source of truth
- Tenant dashboards that include the `households` tab automatically get the full scorecard layout and partner filter; others fall back to a simple screen count

## Test plan
- [ ] `terraform validate` passes
- [ ] `terraform apply` creates all cards and dashboards (tenant dashboard text-card reordering errors are a known provider bug — changes still apply)
- [ ] Open Metabase → verify each tenant collection shows the dashboard pinned at the top with correct description
- [ ] Verify Global dashboard has 4 tabs with correct card layouts
- [ ] Verify tenant dashboards show partner filter dropdown with multi-select
- [ ] Verify Last 30 Days tab data is scoped correctly (compare card values to raw SQL)
- [ ] Verify GA tab shows MAU chart (requires BigQuery enabled)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Major analytics expansion: Global and per-tenant dashboards (All-Time, Last 30 Days, Households) with 35+ new cards, scorecards, charts and tables; Google Analytics monthly active users cards; many new SQL-driven visualizations (incomes, assets, languages, ages, expenses, top partners/counties, benefits, immediate needs).
  * Dashboard-level partner filter support and per-tenant partner dropdowns for targeted views.

* **Documentation**
  * Clarified BigQuery service-account setup and rotation with project-scoped instructions and security notes.

* **Chores**
  * Added tooling support for external data lookups and ignored tfplan artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->