### PR TITLE
Fix dashcard ordering to match Metabase's visual position sort

### DIFF
--- a/dashboards/households.tf
+++ b/dashboards/households.tf
@@ -292,8 +292,10 @@ locals {
   }
 
   # Dashboard layout for Tab 4: Households (CO only)
-  # Split into data cards and text cards to avoid Terraform tuple type mismatch
-  # in conditional expressions (text cards have different visualization_settings shape)
+  # Text blocks are interleaved at their correct visual positions (sorted by row/col)
+  # so the order matches what Metabase returns after saving. The mixed
+  # visualization_settings types (empty {} vs {virtual_card, text}) create a tuple,
+  # so metabase.tf wraps this in jsondecode(jsonencode()) for conditional compatibility.
 
   tenant_dashboard_households_data_layout = {
     for k, v in var.tenants : k => [
@@ -388,7 +390,26 @@ locals {
         series                 = []
         visualization_settings = {}
       },
-      # Row 4: 2 age distribution charts
+      # Row 4: Text block + 2 age distribution charts
+      {
+        card_id            = null
+        dashboard_tab_id   = 4
+        row                = 4
+        col                = 0
+        size_x             = 6
+        size_y             = 8
+        parameter_mappings = []
+        series             = []
+        visualization_settings = {
+          virtual_card = {
+            name                   = null
+            dataset_query          = {}
+            display                = "text"
+            visualization_settings = {}
+          }
+          text = "### Heads of Household\nThe head of household is the person who filled out the screener. If there is more than one adult in the household, the head of household is the oldest adult.\n\n### Age Groups\nAge bins follow U.S. Census Bureau conventions.\n\n**Head of Household:** 0-18, 19-24, 25-44, 45-64, 65+\n**All Members:** <5, 5-18, 19-24, 25-44, 45-64, 65+"
+        }
+      },
       {
         card_id          = tonumber(metabase_card.tenant_head_of_household_ages[k].id)
         dashboard_tab_id = 4
@@ -450,7 +471,26 @@ locals {
         series                 = []
         visualization_settings = {}
       },
-      # Row 20: Income/assets distributions
+      # Row 20: Text block + income/assets distributions
+      {
+        card_id            = null
+        dashboard_tab_id   = 4
+        row                = 20
+        col                = 0
+        size_x             = 6
+        size_y             = 8
+        parameter_mappings = []
+        series             = []
+        visualization_settings = {
+          virtual_card = {
+            name                   = null
+            dataset_query          = {}
+            display                = "text"
+            visualization_settings = {}
+          }
+          text = "### Household Assets & Income\nAssets include savings, checking, and investment accounts.\n\nHouseholds reporting **$50,000+** in assets are likely homeowners (home equity included)."
+        }
+      },
       {
         card_id          = tonumber(metabase_card.tenant_household_income_distribution[k].id)
         dashboard_tab_id = 4
@@ -515,45 +555,4 @@ locals {
     ]
   }
 
-  # Text blocks for Tab 4 (separate from data cards to avoid tuple type mismatch)
-  tenant_dashboard_households_text_layout = [
-    {
-      card_id            = null
-      dashboard_tab_id   = 4
-      row                = 4
-      col                = 0
-      size_x             = 6
-      size_y             = 8
-      parameter_mappings = []
-      series             = []
-      visualization_settings = {
-        virtual_card = {
-          name                   = null
-          dataset_query          = {}
-          display                = "text"
-          visualization_settings = {}
-        }
-        text = "### Heads of Household\nThe head of household is the person who filled out the screener. If there is more than one adult in the household, the head of household is the oldest adult.\n\n### Age Groups\nAge bins follow U.S. Census Bureau conventions.\n\n**Head of Household:** 0-18, 19-24, 25-44, 45-64, 65+\n**All Members:** <5, 5-18, 19-24, 25-44, 45-64, 65+"
-      }
-    },
-    {
-      card_id            = null
-      dashboard_tab_id   = 4
-      row                = 20
-      col                = 0
-      size_x             = 6
-      size_y             = 8
-      parameter_mappings = []
-      series             = []
-      visualization_settings = {
-        virtual_card = {
-          name                   = null
-          dataset_query          = {}
-          display                = "text"
-          visualization_settings = {}
-        }
-        text = "### Household Assets & Income\nAssets include savings, checking, and investment accounts.\n\nHouseholds reporting **$50,000+** in assets are likely homeowners (home equity included)."
-      }
-    },
-  ]
 }

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -731,7 +731,26 @@ resource "metabase_dashboard" "analytics" {
         series                 = []
         visualization_settings = {}
       },
-      # Row 4: Age distribution charts
+      # Row 4: Text block + age distribution charts
+      {
+        card_id            = null
+        dashboard_tab_id   = 3
+        row                = 4
+        col                = 0
+        size_x             = 6
+        size_y             = 8
+        parameter_mappings = []
+        series             = []
+        visualization_settings = {
+          virtual_card = {
+            name                   = null
+            dataset_query          = {}
+            display                = "text"
+            visualization_settings = {}
+          }
+          text = "### Heads of Household\nThe head of household is the person who filled out the screener. If there is more than one adult in the household, the head of household is the oldest adult.\n\n### Age Groups\nAge bins follow U.S. Census Bureau conventions.\n\n**Head of Household:** 0-18, 19-24, 25-44, 45-64, 65+\n**All Members:** <5, 5-18, 19-24, 25-44, 45-64, 65+"
+        }
+      },
       {
         card_id                = tonumber(metabase_card.global_head_of_household_ages.id)
         dashboard_tab_id       = 3
@@ -777,7 +796,26 @@ resource "metabase_dashboard" "analytics" {
         series                 = []
         visualization_settings = {}
       },
-      # Row 20: Income/assets distributions
+      # Row 20: Text block + income/assets distributions
+      {
+        card_id            = null
+        dashboard_tab_id   = 3
+        row                = 20
+        col                = 0
+        size_x             = 6
+        size_y             = 8
+        parameter_mappings = []
+        series             = []
+        visualization_settings = {
+          virtual_card = {
+            name                   = null
+            dataset_query          = {}
+            display                = "text"
+            visualization_settings = {}
+          }
+          text = "### Household Assets & Income\nAssets include savings, checking, and investment accounts.\n\nHouseholds reporting **$50,000+** in assets are likely homeowners (home equity included)."
+        }
+      },
       {
         card_id                = tonumber(metabase_card.global_household_income_distribution.id)
         dashboard_tab_id       = 3
@@ -822,47 +860,6 @@ resource "metabase_dashboard" "analytics" {
         parameter_mappings     = []
         series                 = []
         visualization_settings = {}
-      },
-    ],
-    # Tab 3 text blocks (separate list for type consistency)
-    [
-      {
-        card_id            = null
-        dashboard_tab_id   = 3
-        row                = 4
-        col                = 0
-        size_x             = 6
-        size_y             = 8
-        parameter_mappings = []
-        series             = []
-        visualization_settings = {
-          virtual_card = {
-            name                   = null
-            dataset_query          = {}
-            display                = "text"
-            visualization_settings = {}
-          }
-          text = "### Heads of Household\nThe head of household is the person who filled out the screener. If there is more than one adult in the household, the head of household is the oldest adult.\n\n### Age Groups\nAge bins follow U.S. Census Bureau conventions.\n\n**Head of Household:** 0-18, 19-24, 25-44, 45-64, 65+\n**All Members:** <5, 5-18, 19-24, 25-44, 45-64, 65+"
-        }
-      },
-      {
-        card_id            = null
-        dashboard_tab_id   = 3
-        row                = 20
-        col                = 0
-        size_x             = 6
-        size_y             = 8
-        parameter_mappings = []
-        series             = []
-        visualization_settings = {
-          virtual_card = {
-            name                   = null
-            dataset_query          = {}
-            display                = "text"
-            visualization_settings = {}
-          }
-          text = "### Household Assets & Income\nAssets include savings, checking, and investment accounts.\n\nHouseholds reporting **$50,000+** in assets are likely homeowners (home equity included)."
-        }
       },
     ],
     # -------------------------------------------------------------------------
@@ -1159,9 +1156,9 @@ resource "metabase_dashboard" "tenant_analytics" {
     ],
     # Tab 3: Last 30 Days Performance
     local.tenant_has_tab[each.key]["last_30_days"] ? local.tenant_dashboard_last_30_days_layout[each.key] : [],
-    # Tab 4: Households
-    local.tenant_has_tab[each.key]["households"] ? local.tenant_dashboard_households_data_layout[each.key] : [],
-    local.tenant_has_tab[each.key]["households"] ? local.tenant_dashboard_households_text_layout : [],
+    # Tab 4: Households (jsondecode/jsonencode normalizes the mixed tuple type
+    # so the conditional can match against an empty list)
+    local.tenant_has_tab[each.key]["households"] ? jsondecode(jsonencode(local.tenant_dashboard_households_data_layout[each.key])) : [],
     # Tab 5: Benefits & Immediate Needs (all tenants)
     local.tenant_dashboard_benefits_needs_layout[each.key],
   ))

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -1156,9 +1156,9 @@ resource "metabase_dashboard" "tenant_analytics" {
     ],
     # Tab 3: Last 30 Days Performance
     local.tenant_has_tab[each.key]["last_30_days"] ? local.tenant_dashboard_last_30_days_layout[each.key] : [],
-    # Tab 4: Households (jsondecode/jsonencode normalizes the mixed tuple type
-    # so the conditional can match against an empty list)
-    local.tenant_has_tab[each.key]["households"] ? jsondecode(jsonencode(local.tenant_dashboard_households_data_layout[each.key])) : [],
+    # Tab 4: Households (flatten+for avoids the conditional type mismatch
+    # between the mixed text/data tuple and an empty list)
+    flatten([for k in [each.key] : local.tenant_dashboard_households_data_layout[k] if local.tenant_has_tab[k]["households"]]),
     # Tab 5: Benefits & Immediate Needs (all tenants)
     local.tenant_dashboard_benefits_needs_layout[each.key],
   ))


### PR DESCRIPTION
**The problem:** Metabase reorders dashboard cards by visual position (row/col) when it saves them. But our Terraform config sent data cards and text cards as **two separate concatenated lists** — all data cards first, then all text cards appended at the end. So every time Terraform applied:

1. Terraform sends: `[scorecard, scorecard, ..., age_chart, age_chart, ..., income_chart, ...] + [text_block_row4, text_block_row20]`
2. Metabase saves them, then returns them sorted by position: `[scorecard, scorecard, ..., text_block_row4, age_chart, age_chart, ..., text_block_row20, income_chart, ...]`
3. Terraform compares what it sent vs what it got back → **mismatch** → "Provider produced inconsistent result after apply"
4. Next run, same thing happens → **never converges**

**The fix:** Interleave the text cards at their correct visual positions within the data card list, so the order we send matches the order Metabase returns:

```
Before (two separate lists concatenated):
  data_layout:  [scorecards → age_charts → sizes → income_charts → tables]
  text_layout:  [text_block_row4, text_block_row20]
  concat(data_layout, text_layout)  ← text blocks always at the end

After (single list, visually ordered):
  layout: [scorecards → text_block_row4 → age_charts → sizes → text_block_row20 → income_charts → tables]
```

This affects both the **tenant dashboard** (in `households.tf`) and the **global dashboard** (in `metabase.tf` Tab 3). The original split was based on a concern about Terraform tuple type mismatches, but the Benefits tab already proves that mixing text and data cards in the same list works fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Households dashboard text blocks are now embedded inline with related charts across the Households tabs, so explanatory text appears interleaved with data visualizations.
  * Dashboard JSON/layout composition simplified to remove a separate text-block structure, improving layout consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->