### PR TITLE
Add County filter to all tenant dashboards

### DIFF
--- a/dashboards/benefits_and_immediate_needs.tf
+++ b/dashboards/benefits_and_immediate_needs.tf
@@ -8,8 +8,8 @@ resource "metabase_card" "tenant_completed_screeners" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT count(*) AS \"Completed Screeners\" FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT count(*) AS \"Completed Screeners\" FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = { "scalar.field" = "count" }
@@ -25,8 +25,8 @@ resource "metabase_card" "tenant_already_had_benefits_pct" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT count(*) FILTER (WHERE has_benefits = 'true')::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT count(*) FILTER (WHERE has_benefits = 'true')::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = local.benefits_pct_visualization_settings
@@ -42,8 +42,8 @@ resource "metabase_card" "tenant_qualified_for_benefits_pct" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = local.benefits_pct_visualization_settings
@@ -59,8 +59,8 @@ resource "metabase_card" "tenant_qualified_for_tax_creds_pct" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT count(*) FILTER (WHERE tax_credits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT count(*) FILTER (WHERE tax_credits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = local.benefits_pct_visualization_settings
@@ -79,7 +79,7 @@ resource "metabase_card" "tenant_current_benefits_table" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/current_benefits.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -101,7 +101,7 @@ resource "metabase_card" "tenant_qualified_benefits_table" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/qualified_benefits.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -122,7 +122,7 @@ resource "metabase_card" "tenant_immediate_needs_table" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/immediate_needs.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -178,11 +178,18 @@ locals {
         col              = 0
         size_x           = 6
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_completed_screeners[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_completed_screeners[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_completed_screeners[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -193,11 +200,18 @@ locals {
         col              = 6
         size_x           = 6
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_already_had_benefits_pct[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_already_had_benefits_pct[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_already_had_benefits_pct[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -208,11 +222,18 @@ locals {
         col              = 12
         size_x           = 6
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_qualified_for_benefits_pct[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_for_benefits_pct[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_for_benefits_pct[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -223,11 +244,18 @@ locals {
         col              = 18
         size_x           = 6
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -238,11 +266,18 @@ locals {
         col              = 0
         size_x           = 12
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_current_benefits_table[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_current_benefits_table[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_current_benefits_table[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -253,11 +288,18 @@ locals {
         col              = 12
         size_x           = 12
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_qualified_benefits_table[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_benefits_table[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_benefits_table[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -268,11 +310,18 @@ locals {
         col              = 0
         size_x           = 12
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_immediate_needs_table[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_immediate_needs_table[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_immediate_needs_table[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       }

--- a/dashboards/config_template.tf
+++ b/dashboards/config_template.tf
@@ -84,7 +84,7 @@ locals {
 
   # Per-tenant tab selection — order determines tab display order
   tenant_tabs = {
-    nc                = ["google_analytics", "all_time", "benefits_needs"]
+    nc                = ["all_time", "last_30_days", "households", "benefits_needs", "google_analytics"]
     co                = ["all_time", "last_30_days", "households", "benefits_needs", "google_analytics"]
     tx                = ["all_time", "last_30_days", "households", "benefits_needs", "google_analytics"]
     il                = ["all_time", "last_30_days", "households", "benefits_needs", "google_analytics"]
@@ -108,9 +108,31 @@ locals {
         name           = "partner"
         "display-name" = "Partner"
         type           = "dimension"
-        dimension      = ["field", tonumber(data.external.partner_field_ids.result[k]), null]
+        dimension      = ["field", tonumber(data.external.filter_field_ids.result["${k}__partner"]), null]
         "widget-type"  = "string/="
       }
     }
+  }
+
+  # Per-tenant template-tags for county field filter
+  county_template_tags = {
+    for k, v in var.tenants : k => {
+      county = {
+        id             = "county_filter"
+        name           = "county"
+        "display-name" = "County"
+        type           = "dimension"
+        dimension      = ["field", tonumber(data.external.filter_field_ids.result["${k}__county"]), null]
+        "widget-type"  = "string/="
+      }
+    }
+  }
+
+  # Merged template-tags: partner + county (used by all cards that support both filters)
+  filter_template_tags = {
+    for k, v in var.tenants : k => merge(
+      local.partner_template_tags[k],
+      local.county_template_tags[k],
+    )
   }
 }

--- a/dashboards/global_cards.tf
+++ b/dashboards/global_cards.tf
@@ -6,9 +6,11 @@
 # Helper: strip the Metabase partner template-tag placeholder from SQL files
 # =============================================================================
 locals {
-  # For SQL files: remove the partner filter clause
+  # For SQL files: remove the partner and county filter clauses
   _partner_clause     = " [[AND {{partner}}]]"
   _partner_clause_alt = "\n    [[AND {{partner}}]]"
+  _county_clause      = " [[AND {{county}}]]"
+  _county_clause_alt  = "\n    [[AND {{county}}]]"
 
   # Base config for global cards (no template-tags, no partner filter)
   global_card_base_config = {
@@ -179,12 +181,11 @@ resource "metabase_card" "global_top_partners" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
-          replace(
+        query = replace(replace(
+          replace(replace(
             templatefile("${path.module}/sql/top_partners.sql", {}),
-            local._partner_clause_alt, ""
-          ),
-          local._partner_clause, ""
+            local._partner_clause_alt, ""), local._partner_clause, ""),
+          local._county_clause_alt, ""), local._county_clause, ""
         )
       }
     }
@@ -208,12 +209,11 @@ resource "metabase_card" "global_top_counties" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
-          replace(
+        query = replace(replace(
+          replace(replace(
             templatefile("${path.module}/sql/top_counties.sql", {}),
-            local._partner_clause_alt, ""
-          ),
-          local._partner_clause, ""
+            local._partner_clause_alt, ""), local._partner_clause, ""),
+          local._county_clause_alt, ""), local._county_clause, ""
         )
       }
     }
@@ -362,12 +362,11 @@ resource "metabase_card" "global_top_partners_30d" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
-          replace(
+        query = replace(replace(
+          replace(replace(
             templatefile("${path.module}/sql/top_partners_30d.sql", {}),
-            local._partner_clause_alt, ""
-          ),
-          local._partner_clause, ""
+            local._partner_clause_alt, ""), local._partner_clause, ""),
+          local._county_clause_alt, ""), local._county_clause, ""
         )
       }
     }
@@ -391,12 +390,11 @@ resource "metabase_card" "global_top_counties_30d" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
-          replace(
+        query = replace(replace(
+          replace(replace(
             templatefile("${path.module}/sql/top_counties_30d.sql", {}),
-            local._partner_clause_alt, ""
-          ),
-          local._partner_clause, ""
+            local._partner_clause_alt, ""), local._partner_clause, ""),
+          local._county_clause_alt, ""), local._county_clause, ""
         )
       }
     }
@@ -512,12 +510,11 @@ resource "metabase_card" "global_head_of_household_ages" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
-          replace(
+        query = replace(replace(
+          replace(replace(
             templatefile("${path.module}/sql/household_head_ages.sql", {}),
-            local._partner_clause_alt, ""
-          ),
-          local._partner_clause, ""
+            local._partner_clause_alt, ""), local._partner_clause, ""),
+          local._county_clause_alt, ""), local._county_clause, ""
         )
       }
     }
@@ -534,12 +531,11 @@ resource "metabase_card" "global_household_member_ages" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
-          replace(
+        query = replace(replace(
+          replace(replace(
             templatefile("${path.module}/sql/household_member_ages.sql", {}),
-            local._partner_clause_alt, ""
-          ),
-          local._partner_clause, ""
+            local._partner_clause_alt, ""), local._partner_clause, ""),
+          local._county_clause_alt, ""), local._county_clause, ""
         )
       }
     }
@@ -556,12 +552,11 @@ resource "metabase_card" "global_household_sizes" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
-          replace(
+        query = replace(replace(
+          replace(replace(
             templatefile("${path.module}/sql/household_sizes.sql", {}),
-            local._partner_clause_alt, ""
-          ),
-          local._partner_clause, ""
+            local._partner_clause_alt, ""), local._partner_clause, ""),
+          local._county_clause_alt, ""), local._county_clause, ""
         )
       }
     }
@@ -578,12 +573,11 @@ resource "metabase_card" "global_household_languages" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
-          replace(
+        query = replace(replace(
+          replace(replace(
             templatefile("${path.module}/sql/household_languages.sql", {}),
-            local._partner_clause_alt, ""
-          ),
-          local._partner_clause, ""
+            local._partner_clause_alt, ""), local._partner_clause, ""),
+          local._county_clause_alt, ""), local._county_clause, ""
         )
       }
     }
@@ -606,12 +600,11 @@ resource "metabase_card" "global_household_income_distribution" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
-          replace(
+        query = replace(replace(
+          replace(replace(
             templatefile("${path.module}/sql/household_income_distribution.sql", {}),
-            local._partner_clause_alt, ""
-          ),
-          local._partner_clause, ""
+            local._partner_clause_alt, ""), local._partner_clause, ""),
+          local._county_clause_alt, ""), local._county_clause, ""
         )
       }
     }
@@ -628,12 +621,11 @@ resource "metabase_card" "global_household_assets_distribution" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
-          replace(
+        query = replace(replace(
+          replace(replace(
             templatefile("${path.module}/sql/household_assets_distribution.sql", {}),
-            local._partner_clause_alt, ""
-          ),
-          local._partner_clause, ""
+            local._partner_clause_alt, ""), local._partner_clause, ""),
+          local._county_clause_alt, ""), local._county_clause, ""
         )
       }
     }
@@ -649,12 +641,11 @@ resource "metabase_card" "global_income_streams" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
-          replace(
+        query = replace(replace(
+          replace(replace(
             templatefile("${path.module}/sql/income_streams.sql", {}),
-            local._partner_clause_alt, ""
-          ),
-          local._partner_clause, ""
+            local._partner_clause_alt, ""), local._partner_clause, ""),
+          local._county_clause_alt, ""), local._county_clause, ""
         )
       }
     }
@@ -672,12 +663,11 @@ resource "metabase_card" "global_common_expenses" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
-          replace(
+        query = replace(replace(
+          replace(replace(
             templatefile("${path.module}/sql/common_expenses.sql", {}),
-            local._partner_clause_alt, ""
-          ),
-          local._partner_clause, ""
+            local._partner_clause_alt, ""), local._partner_clause, ""),
+          local._county_clause_alt, ""), local._county_clause, ""
         )
       }
     }
@@ -716,9 +706,9 @@ resource "metabase_card" "global_current_benefits_table" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
+        query = replace(replace(
           templatefile("${path.module}/sql/current_benefits.sql", {}),
-          local._partner_clause, ""
+          local._partner_clause, ""), local._county_clause, ""
         )
       }
     }
@@ -738,9 +728,9 @@ resource "metabase_card" "global_qualified_benefits_table" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
+        query = replace(replace(
           templatefile("${path.module}/sql/qualified_benefits.sql", {}),
-          local._partner_clause, ""
+          local._partner_clause, ""), local._county_clause, ""
         )
       }
     }
@@ -759,9 +749,9 @@ resource "metabase_card" "global_immediate_needs_table" {
       type     = "native"
       database = local.global_db_id
       native = {
-        query = replace(
+        query = replace(replace(
           templatefile("${path.module}/sql/immediate_needs.sql", {}),
-          local._partner_clause, ""
+          local._partner_clause, ""), local._county_clause, ""
         )
       }
     }

--- a/dashboards/households.tf
+++ b/dashboards/households.tf
@@ -11,8 +11,8 @@ resource "metabase_card" "tenant_median_household_size" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY household_size) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY household_size) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = { "scalar.field" = "median" }
@@ -28,8 +28,8 @@ resource "metabase_card" "tenant_median_household_assets" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY household_assets) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY household_assets) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -48,8 +48,8 @@ resource "metabase_card" "tenant_median_annual_income" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_income * 12) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_income * 12) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -68,8 +68,8 @@ resource "metabase_card" "tenant_median_monthly_income" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_income) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_income) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -88,8 +88,8 @@ resource "metabase_card" "tenant_median_monthly_expenses" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_expenses) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY monthly_expenses) AS median FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -112,7 +112,7 @@ resource "metabase_card" "tenant_head_of_household_ages" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/household_head_ages.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = local.households_pct_bar_chart_settings["Age Group"]
@@ -130,7 +130,7 @@ resource "metabase_card" "tenant_household_member_ages" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/household_member_ages.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = local.households_pct_bar_chart_settings["Age Group"]
@@ -150,7 +150,7 @@ resource "metabase_card" "tenant_household_sizes" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/household_sizes.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = local.households_pct_bar_chart_settings["Household Size"]
@@ -168,7 +168,7 @@ resource "metabase_card" "tenant_household_languages" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/household_languages.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -194,7 +194,7 @@ resource "metabase_card" "tenant_household_income_distribution" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/household_income_distribution.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = local.households_pct_bar_chart_settings["Income Range"]
@@ -212,7 +212,7 @@ resource "metabase_card" "tenant_household_assets_distribution" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/household_assets_distribution.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = local.households_pct_bar_chart_settings["Asset Range"]
@@ -231,7 +231,7 @@ resource "metabase_card" "tenant_income_streams" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/income_streams.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -250,7 +250,7 @@ resource "metabase_card" "tenant_common_expenses" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/common_expenses.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -307,11 +307,18 @@ locals {
         col              = 0
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_completed_screeners[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_completed_screeners[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_completed_screeners[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -322,11 +329,18 @@ locals {
         col              = 4
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_median_household_size[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_median_household_size[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_median_household_size[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -337,11 +351,18 @@ locals {
         col              = 8
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_median_household_assets[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_median_household_assets[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_median_household_assets[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -352,11 +373,18 @@ locals {
         col              = 12
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_median_annual_income[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_median_annual_income[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_median_annual_income[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -367,11 +395,18 @@ locals {
         col              = 16
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_median_monthly_income[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_median_monthly_income[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_median_monthly_income[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -382,11 +417,18 @@ locals {
         col              = 20
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_median_monthly_expenses[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_median_monthly_expenses[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_median_monthly_expenses[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -417,11 +459,18 @@ locals {
         col              = 6
         size_x           = 9
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_head_of_household_ages[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_head_of_household_ages[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_head_of_household_ages[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -432,11 +481,18 @@ locals {
         col              = 15
         size_x           = 9
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_household_member_ages[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_household_member_ages[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_household_member_ages[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -448,11 +504,18 @@ locals {
         col              = 0
         size_x           = 12
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_household_sizes[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_household_sizes[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_household_sizes[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -463,11 +526,18 @@ locals {
         col              = 12
         size_x           = 12
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_household_languages[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_household_languages[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_household_languages[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -498,11 +568,18 @@ locals {
         col              = 6
         size_x           = 9
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_household_income_distribution[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_household_income_distribution[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_household_income_distribution[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -513,11 +590,18 @@ locals {
         col              = 15
         size_x           = 9
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_household_assets_distribution[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_household_assets_distribution[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_household_assets_distribution[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -529,11 +613,18 @@ locals {
         col              = 0
         size_x           = 12
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_income_streams[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_income_streams[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_income_streams[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -544,11 +635,18 @@ locals {
         col              = 12
         size_x           = 12
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_common_expenses[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_common_expenses[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_common_expenses[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },

--- a/dashboards/last_30_days.tf
+++ b/dashboards/last_30_days.tf
@@ -11,8 +11,8 @@ resource "metabase_card" "tenant_completed_screeners_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT count(*) FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT count(*) FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = { "scalar.field" = "count" }
@@ -28,8 +28,8 @@ resource "metabase_card" "tenant_qualified_for_benefits_pct_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = local.benefits_pct_visualization_settings
@@ -45,8 +45,8 @@ resource "metabase_card" "tenant_median_annual_benefits_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -65,8 +65,8 @@ resource "metabase_card" "tenant_median_monthly_benefits_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -85,8 +85,8 @@ resource "metabase_card" "tenant_qualified_for_tax_creds_pct_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT count(*) FILTER (WHERE tax_credits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT count(*) FILTER (WHERE tax_credits_annual > 0)::float / NULLIF(count(*), 0) as pct FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = local.benefits_pct_visualization_settings
@@ -102,8 +102,8 @@ resource "metabase_card" "tenant_median_annual_tax_credits_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0 AND submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -126,7 +126,7 @@ resource "metabase_card" "tenant_daily_screeners_30d" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]] GROUP BY submission_date ORDER BY submission_date"
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -151,7 +151,7 @@ resource "metabase_card" "tenant_top_partners_30d" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/top_partners_30d.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -176,7 +176,7 @@ resource "metabase_card" "tenant_top_counties_30d" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/top_counties_30d.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -204,11 +204,18 @@ locals {
         col              = 0
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_completed_screeners_30d[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_completed_screeners_30d[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_completed_screeners_30d[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -219,11 +226,18 @@ locals {
         col              = 4
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_qualified_for_benefits_pct_30d[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_for_benefits_pct_30d[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_for_benefits_pct_30d[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -234,11 +248,18 @@ locals {
         col              = 8
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_median_annual_benefits_30d[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_median_annual_benefits_30d[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_median_annual_benefits_30d[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -249,11 +270,18 @@ locals {
         col              = 12
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_median_monthly_benefits_30d[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_median_monthly_benefits_30d[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_median_monthly_benefits_30d[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -264,11 +292,18 @@ locals {
         col              = 16
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct_30d[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct_30d[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct_30d[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -279,11 +314,18 @@ locals {
         col              = 20
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_median_annual_tax_credits_30d[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_median_annual_tax_credits_30d[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_median_annual_tax_credits_30d[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -295,11 +337,18 @@ locals {
         col              = 0
         size_x           = 24
         size_y           = 6
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_daily_screeners_30d[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_daily_screeners_30d[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_daily_screeners_30d[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -311,11 +360,18 @@ locals {
         col              = 0
         size_x           = 12
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_top_partners_30d[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_top_partners_30d[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_top_partners_30d[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -326,11 +382,18 @@ locals {
         col              = 12
         size_x           = 12
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_top_counties_30d[k].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_top_counties_30d[k].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_top_counties_30d[k].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },

--- a/dashboards/last_30_days.tf
+++ b/dashboards/last_30_days.tf
@@ -125,7 +125,7 @@ resource "metabase_card" "tenant_daily_screeners_30d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]] GROUP BY submission_date ORDER BY submission_date"
+        query           = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days' [[AND {{partner}}]] [[AND {{county}}]] GROUP BY submission_date ORDER BY submission_date"
         "template-tags" = local.filter_template_tags[each.key]
       }
     }

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -112,12 +112,12 @@ data "metabase_table" "tenant_screen_summary_tables" {
   db_id  = tonumber(metabase_database.tenant_postgres[each.key].id)
 }
 
-# Look up Metabase field IDs for the partner column (needed for field filter multi-select).
+# Look up Metabase field IDs for filter columns (needed for field filter multi-select).
 # Field IDs are environment-specific; this script queries the Metabase API at plan time.
-data "external" "partner_field_ids" {
+data "external" "filter_field_ids" {
   depends_on = [time_sleep.wait_for_database_sync]
 
-  program = ["python3", "${path.module}/scripts/get_partner_field_ids.py"]
+  program = ["python3", "${path.module}/scripts/get_field_ids.py"]
 
   query = {
     metabase_url = var.metabase_url
@@ -126,6 +126,7 @@ data "external" "partner_field_ids" {
     database_ids = jsonencode({
       for k, v in var.tenants : k => metabase_database.tenant_postgres[k].id
     })
+    field_names = jsonencode(["partner", "county"])
   }
 }
 
@@ -280,8 +281,8 @@ resource "metabase_card" "tenant_median_annual_benefits" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -302,8 +303,8 @@ resource "metabase_card" "tenant_median_monthly_benefits" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY non_tax_credit_benefits_annual / 12.0) AS median FROM analytics.mart_screener_data WHERE non_tax_credit_benefits_annual > 0 [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -324,8 +325,8 @@ resource "metabase_card" "tenant_median_annual_tax_credits" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0 [[AND {{partner}}]]"
-        "template-tags" = local.partner_template_tags[each.key]
+        query           = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY tax_credits_annual) AS median FROM analytics.mart_screener_data WHERE tax_credits_annual > 0 [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -348,7 +349,7 @@ resource "metabase_card" "tenant_daily_screeners_7d" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '6 days' [[AND {{partner}}]] GROUP BY submission_date ORDER BY submission_date"
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = {
@@ -373,7 +374,7 @@ resource "metabase_card" "tenant_top_partners" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/top_partners.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -400,7 +401,7 @@ resource "metabase_card" "tenant_top_counties" {
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
         query           = templatefile("${path.module}/sql/top_counties.sql", {})
-        "template-tags" = local.partner_template_tags[each.key]
+        "template-tags" = local.filter_template_tags[each.key]
       }
     }
     visualization_settings = merge(local.tenant_table_card_config.visualization_settings, {
@@ -427,6 +428,22 @@ resource "metabase_card" "tenant_partner_values" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native   = { query = "SELECT DISTINCT partner FROM analytics.mart_screener_data WHERE partner IS NOT NULL ORDER BY partner" }
+    }
+  }))
+}
+
+# Helper card for county filter dropdown values
+resource "metabase_card" "tenant_county_values" {
+  for_each = var.tenants
+
+  json = jsonencode(merge(local.tenant_card_base_config, {
+    name          = "County Values (Filter Helper)"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    display       = "table"
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native   = { query = "SELECT DISTINCT county FROM analytics.mart_screener_data WHERE county IS NOT NULL AND county <> '' ORDER BY county" }
     }
   }))
 }
@@ -993,6 +1010,19 @@ resource "metabase_dashboard" "tenant_analytics" {
           card_id     = tonumber(metabase_card.tenant_partner_values[each.key].id)
           value_field = ["field", "partner", { "base-type" = "type/Text" }]
         }
+      },
+      {
+        id                 = "county_filter"
+        name               = "County"
+        slug               = "county"
+        type               = "string/="
+        sectionId          = "string"
+        values_query_type  = "list"
+        values_source_type = "card"
+        values_source_config = {
+          card_id     = tonumber(metabase_card.tenant_county_values[each.key].id)
+          value_field = ["field", "county", { "base-type" = "type/Text" }]
+        }
       }
     ] : []
   )
@@ -1013,11 +1043,18 @@ resource "metabase_dashboard" "tenant_analytics" {
         col              = 0
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_completed_screeners[each.key].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_completed_screeners[each.key].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_completed_screeners[each.key].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -1028,11 +1065,18 @@ resource "metabase_dashboard" "tenant_analytics" {
         col              = 4
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_qualified_for_benefits_pct[each.key].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_for_benefits_pct[each.key].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_for_benefits_pct[each.key].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -1043,11 +1087,18 @@ resource "metabase_dashboard" "tenant_analytics" {
         col              = 8
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_median_annual_benefits[each.key].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_median_annual_benefits[each.key].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_median_annual_benefits[each.key].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -1058,11 +1109,18 @@ resource "metabase_dashboard" "tenant_analytics" {
         col              = 12
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_median_monthly_benefits[each.key].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_median_monthly_benefits[each.key].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_median_monthly_benefits[each.key].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -1073,11 +1131,18 @@ resource "metabase_dashboard" "tenant_analytics" {
         col              = 16
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct[each.key].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct[each.key].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_qualified_for_tax_creds_pct[each.key].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -1088,11 +1153,18 @@ resource "metabase_dashboard" "tenant_analytics" {
         col              = 20
         size_x           = 4
         size_y           = 4
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_median_annual_tax_credits[each.key].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_median_annual_tax_credits[each.key].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_median_annual_tax_credits[each.key].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -1103,11 +1175,18 @@ resource "metabase_dashboard" "tenant_analytics" {
         col              = 0
         size_x           = 24
         size_y           = 6
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_daily_screeners_7d[each.key].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_daily_screeners_7d[each.key].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_daily_screeners_7d[each.key].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -1118,11 +1197,18 @@ resource "metabase_dashboard" "tenant_analytics" {
         col              = 0
         size_x           = 12
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_top_partners[each.key].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_top_partners[each.key].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_top_partners[each.key].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },
@@ -1133,11 +1219,18 @@ resource "metabase_dashboard" "tenant_analytics" {
         col              = 12
         size_x           = 12
         size_y           = 8
-        parameter_mappings = [{
-          parameter_id = "partner_filter"
-          card_id      = tonumber(metabase_card.tenant_top_counties[each.key].id)
-          target       = ["dimension", ["template-tag", "partner"]]
-        }]
+        parameter_mappings = [
+          {
+            parameter_id = "partner_filter"
+            card_id      = tonumber(metabase_card.tenant_top_counties[each.key].id)
+            target       = ["dimension", ["template-tag", "partner"]]
+          },
+          {
+            parameter_id = "county_filter"
+            card_id      = tonumber(metabase_card.tenant_top_counties[each.key].id)
+            target       = ["dimension", ["template-tag", "county"]]
+          }
+        ]
         series                 = []
         visualization_settings = {}
       },

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -348,7 +348,7 @@ resource "metabase_card" "tenant_daily_screeners_7d" {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
       native = {
-        query           = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '6 days' [[AND {{partner}}]] GROUP BY submission_date ORDER BY submission_date"
+        query           = "SELECT submission_date, count(*) AS screeners FROM analytics.mart_screener_data WHERE submission_date >= CURRENT_DATE - INTERVAL '6 days' [[AND {{partner}}]] [[AND {{county}}]] GROUP BY submission_date ORDER BY submission_date"
         "template-tags" = local.filter_template_tags[each.key]
       }
     }

--- a/dashboards/scripts/get_field_ids.py
+++ b/dashboards/scripts/get_field_ids.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Look up Metabase field IDs for the partner column across all tenant databases.
+"""Look up Metabase field IDs for specified columns across all tenant databases.
 
 Used by Terraform's external data source to dynamically resolve field IDs,
 which differ between environments (local dev, staging, production).
@@ -9,11 +9,12 @@ Input (JSON on stdin):
     "metabase_url": "http://localhost:3001",
     "username": "admin@example.com",
     "password": "secret",
-    "database_ids": "{\"co\": \"3\", \"nc\": \"2\", ...}"
+    "database_ids": "{\"co\": \"3\", \"nc\": \"2\", ...}",
+    "field_names": "[\"partner\", \"county\"]"
   }
 
-Output (JSON on stdout):
-  {"co": "5689", "nc": "6329", ...}
+Output (JSON on stdout – flat keys for Terraform external data source):
+  {"co__partner": "5689", "co__county": "5690", "nc__partner": "6329", ...}
 """
 import json
 import sys
@@ -42,45 +43,50 @@ def get_session(metabase_url, username, password):
     return _load_json(req, "Creating Metabase session")["id"]
 
 
-def get_field_id(metabase_url, session_id, db_id, table_name, schema, field_name):
+def get_field_ids(metabase_url, session_id, db_id, table_name, schema, field_names):
+    """Return a dict of {field_name: field_id_str} for the requested fields."""
     req = urllib.request.Request(
         f"{metabase_url}/api/database/{db_id}/metadata?include=tables.fields",
         headers={"X-Metabase-Session": session_id},
     )
     data = _load_json(req, f"Loading metadata for database {db_id}")
 
+    result = {}
     for table in data.get("tables", []):
         if table.get("name") == table_name and table.get("schema") == schema:
             for field in table.get("fields", []):
-                if field.get("name") == field_name:
-                    return str(field["id"])
-    return ""
+                if field.get("name") in field_names:
+                    result[field["name"]] = str(field["id"])
+    return result
 
 
 def main():
     query = json.load(sys.stdin)
     metabase_url = query["metabase_url"]
     database_ids = json.loads(query["database_ids"])
+    field_names = json.loads(query.get("field_names", '["partner"]'))
 
     session_id = get_session(metabase_url, query["username"], query["password"])
 
     result = {}
     missing = []
     for tenant_key, db_id in database_ids.items():
-        field_id = get_field_id(
+        fields = get_field_ids(
             metabase_url, session_id, db_id,
             table_name="mart_screener_data",
             schema="analytics",
-            field_name="partner",
+            field_names=set(field_names),
         )
-        if field_id:
-            result[tenant_key] = field_id
-        else:
-            missing.append(f"{tenant_key} (db {db_id})")
+        for field_name in field_names:
+            if field_name in fields:
+                # Flat key format: tenant__field (Terraform external data returns flat map)
+                result[f"{tenant_key}__{field_name}"] = fields[field_name]
+            else:
+                missing.append(f"{tenant_key}.{field_name} (db {db_id})")
 
     if missing:
         raise SystemExit(
-            "Could not resolve Metabase field IDs for analytics.mart_screener_data.partner: "
+            "Could not resolve Metabase field IDs for analytics.mart_screener_data: "
             + ", ".join(missing)
         )
 

--- a/dashboards/sql/common_expenses.sql
+++ b/dashboards/sql/common_expenses.sql
@@ -1,6 +1,6 @@
 WITH filtered_screeners AS (
     SELECT id FROM analytics.mart_screener_data
-    WHERE 1=1 [[AND {{partner}}]]
+    WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
 ),
 total AS (
     SELECT count(*) AS total_screeners FROM filtered_screeners

--- a/dashboards/sql/current_benefits.sql
+++ b/dashboards/sql/current_benefits.sql
@@ -1,11 +1,12 @@
-WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]])
+WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]),
+filter_keys AS (SELECT DISTINCT partner, county FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]])
 SELECT
-    benefit as "Benefit Name",
-    SUM(count) as "# of Screeners",
-    SUM(count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
-FROM analytics.mart_previous_benefits
+    pb.benefit as "Benefit Name",
+    SUM(pb.count) as "# of Screeners",
+    SUM(pb.count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
+FROM analytics.mart_previous_benefits pb
+INNER JOIN filter_keys fk ON pb.partner IS NOT DISTINCT FROM fk.partner AND pb.county IS NOT DISTINCT FROM fk.county
 CROSS JOIN totals t
-WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
-GROUP BY benefit
-HAVING SUM(count) > 0
-ORDER BY SUM(count) DESC, benefit ASC
+GROUP BY pb.benefit
+HAVING SUM(pb.count) > 0
+ORDER BY SUM(pb.count) DESC, pb.benefit ASC

--- a/dashboards/sql/current_benefits.sql
+++ b/dashboards/sql/current_benefits.sql
@@ -1,11 +1,11 @@
-WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]])
+WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]])
 SELECT
     benefit as "Benefit Name",
     SUM(count) as "# of Screeners",
     SUM(count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
 FROM analytics.mart_previous_benefits
 CROSS JOIN totals t
-WHERE 1=1 [[AND {{partner}}]]
+WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
 GROUP BY benefit
 HAVING SUM(count) > 0
 ORDER BY SUM(count) DESC

--- a/dashboards/sql/household_assets_distribution.sql
+++ b/dashboards/sql/household_assets_distribution.sql
@@ -1,7 +1,7 @@
 WITH filtered AS (
     SELECT household_assets
     FROM analytics.mart_screener_data
-    WHERE household_assets IS NOT NULL [[AND {{partner}}]]
+    WHERE household_assets IS NOT NULL [[AND {{partner}}]] [[AND {{county}}]]
 ),
 total AS (
     SELECT count(*) AS n FROM filtered

--- a/dashboards/sql/household_head_ages.sql
+++ b/dashboards/sql/household_head_ages.sql
@@ -1,7 +1,7 @@
 WITH filtered AS (
     SELECT age FROM analytics.mart_householdmembers
     WHERE relationship = 'headOfHousehold'
-    [[AND {{partner}}]]
+    [[AND {{partner}}]] [[AND {{county}}]]
 ),
 total AS (
     SELECT count(*) AS n FROM filtered WHERE age IS NOT NULL

--- a/dashboards/sql/household_head_ages.sql
+++ b/dashboards/sql/household_head_ages.sql
@@ -1,7 +1,11 @@
-WITH filtered AS (
-    SELECT age FROM analytics.mart_householdmembers
-    WHERE relationship = 'headOfHousehold'
+WITH filter_keys AS (
+    SELECT DISTINCT partner, county FROM analytics.mart_screener_data WHERE 1=1
     [[AND {{partner}}]] [[AND {{county}}]]
+),
+filtered AS (
+    SELECT hm.age FROM analytics.mart_householdmembers hm
+    INNER JOIN filter_keys fk ON hm.partner IS NOT DISTINCT FROM fk.partner AND hm.county IS NOT DISTINCT FROM fk.county
+    WHERE hm.relationship = 'headOfHousehold'
 ),
 total AS (
     SELECT count(*) AS n FROM filtered WHERE age IS NOT NULL

--- a/dashboards/sql/household_income_distribution.sql
+++ b/dashboards/sql/household_income_distribution.sql
@@ -1,7 +1,7 @@
 WITH filtered AS (
     SELECT monthly_income * 12 AS annual_income
     FROM analytics.mart_screener_data
-    WHERE monthly_income IS NOT NULL [[AND {{partner}}]]
+    WHERE monthly_income IS NOT NULL [[AND {{partner}}]] [[AND {{county}}]]
 ),
 total AS (
     SELECT count(*) AS n FROM filtered

--- a/dashboards/sql/household_languages.sql
+++ b/dashboards/sql/household_languages.sql
@@ -1,7 +1,7 @@
 WITH filtered AS (
     SELECT request_language_code
     FROM analytics.mart_screener_data
-    WHERE 1=1 [[AND {{partner}}]]
+    WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
 ),
 total AS (
     SELECT count(*) AS n FROM filtered

--- a/dashboards/sql/household_member_ages.sql
+++ b/dashboards/sql/household_member_ages.sql
@@ -1,7 +1,7 @@
 WITH filtered AS (
     SELECT age FROM analytics.mart_householdmembers
     WHERE 1=1
-    [[AND {{partner}}]]
+    [[AND {{partner}}]] [[AND {{county}}]]
 ),
 total AS (
     SELECT count(*) AS n FROM filtered WHERE age IS NOT NULL

--- a/dashboards/sql/household_member_ages.sql
+++ b/dashboards/sql/household_member_ages.sql
@@ -1,7 +1,10 @@
-WITH filtered AS (
-    SELECT age FROM analytics.mart_householdmembers
-    WHERE 1=1
+WITH filter_keys AS (
+    SELECT DISTINCT partner, county FROM analytics.mart_screener_data WHERE 1=1
     [[AND {{partner}}]] [[AND {{county}}]]
+),
+filtered AS (
+    SELECT hm.age FROM analytics.mart_householdmembers hm
+    INNER JOIN filter_keys fk ON hm.partner IS NOT DISTINCT FROM fk.partner AND hm.county IS NOT DISTINCT FROM fk.county
 ),
 total AS (
     SELECT count(*) AS n FROM filtered WHERE age IS NOT NULL

--- a/dashboards/sql/household_sizes.sql
+++ b/dashboards/sql/household_sizes.sql
@@ -1,7 +1,7 @@
 WITH filtered AS (
     SELECT household_size
     FROM analytics.mart_screener_data
-    WHERE 1=1 [[AND {{partner}}]]
+    WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
 ),
 total AS (
     SELECT count(*) AS n FROM filtered

--- a/dashboards/sql/immediate_needs.sql
+++ b/dashboards/sql/immediate_needs.sql
@@ -1,10 +1,11 @@
-WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]])
+WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]),
+filter_keys AS (SELECT DISTINCT partner, county FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]])
 SELECT
-    benefit as "Need Category",
-    SUM(count) as "# of Screeners",
-    SUM(count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
-FROM analytics.mart_immediate_needs
+    n.benefit as "Need Category",
+    SUM(n.count) as "# of Screeners",
+    SUM(n.count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
+FROM analytics.mart_immediate_needs n
+INNER JOIN filter_keys fk ON n.partner IS NOT DISTINCT FROM fk.partner AND n.county IS NOT DISTINCT FROM fk.county
 CROSS JOIN totals t
-WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
-GROUP BY benefit
-ORDER BY SUM(count) DESC, benefit ASC
+GROUP BY n.benefit
+ORDER BY SUM(n.count) DESC, n.benefit ASC

--- a/dashboards/sql/immediate_needs.sql
+++ b/dashboards/sql/immediate_needs.sql
@@ -1,10 +1,10 @@
-WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]])
+WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]])
 SELECT
     benefit as "Need Category",
     SUM(count) as "# of Screeners",
     SUM(count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
 FROM analytics.mart_immediate_needs
 CROSS JOIN totals t
-WHERE 1=1 [[AND {{partner}}]]
+WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
 GROUP BY benefit
 ORDER BY SUM(count) DESC

--- a/dashboards/sql/income_streams.sql
+++ b/dashboards/sql/income_streams.sql
@@ -1,6 +1,6 @@
 WITH filtered_screeners AS (
     SELECT id FROM analytics.mart_screener_data
-    WHERE 1=1 [[AND {{partner}}]]
+    WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
 ),
 total AS (
     SELECT count(*) AS total_screeners FROM filtered_screeners

--- a/dashboards/sql/qualified_benefits.sql
+++ b/dashboards/sql/qualified_benefits.sql
@@ -1,12 +1,15 @@
 WITH totals AS (
     SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
+),
+filter_keys AS (
+    SELECT DISTINCT partner, county FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
 )
 SELECT
     qb.benefit as "Benefit Name",
     SUM(qb.count) as "# of Screeners",
     SUM(qb.count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
 FROM analytics.mart_qualified_benefits qb
+INNER JOIN filter_keys fk ON qb.partner IS NOT DISTINCT FROM fk.partner AND qb.county IS NOT DISTINCT FROM fk.county
 CROSS JOIN totals t
-WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
 GROUP BY qb.benefit
 ORDER BY SUM(qb.count) DESC, qb.benefit ASC

--- a/dashboards/sql/qualified_benefits.sql
+++ b/dashboards/sql/qualified_benefits.sql
@@ -1,5 +1,5 @@
 WITH totals AS (
-    SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]]
+    SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
 )
 SELECT
     qb.benefit as "Benefit Name",
@@ -7,6 +7,6 @@ SELECT
     SUM(qb.count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
 FROM analytics.mart_qualified_benefits qb
 CROSS JOIN totals t
-WHERE 1=1 [[AND {{partner}}]]
+WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
 GROUP BY qb.benefit
 ORDER BY SUM(qb.count) DESC

--- a/dashboards/sql/top_counties.sql
+++ b/dashboards/sql/top_counties.sql
@@ -1,6 +1,6 @@
 WITH filtered AS (
     SELECT * FROM analytics.mart_screener_data
-    WHERE 1=1 [[AND {{partner}}]]
+    WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
 ),
 county_counts AS (
     SELECT county, count(*) AS screeners

--- a/dashboards/sql/top_counties_30d.sql
+++ b/dashboards/sql/top_counties_30d.sql
@@ -1,7 +1,7 @@
 WITH filtered AS (
     SELECT * FROM analytics.mart_screener_data
     WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days'
-    [[AND {{partner}}]]
+    [[AND {{partner}}]] [[AND {{county}}]]
 ),
 county_counts AS (
     SELECT county, count(*) AS screeners

--- a/dashboards/sql/top_partners.sql
+++ b/dashboards/sql/top_partners.sql
@@ -1,6 +1,6 @@
 WITH filtered AS (
     SELECT * FROM analytics.mart_screener_data
-    WHERE 1=1 [[AND {{partner}}]]
+    WHERE 1=1 [[AND {{partner}}]] [[AND {{county}}]]
 ),
 ranked AS (
     SELECT partner, count(*) AS screeners

--- a/dashboards/sql/top_partners_30d.sql
+++ b/dashboards/sql/top_partners_30d.sql
@@ -1,7 +1,7 @@
 WITH filtered AS (
     SELECT * FROM analytics.mart_screener_data
     WHERE submission_date >= CURRENT_DATE - INTERVAL '29 days'
-    [[AND {{partner}}]]
+    [[AND {{partner}}]] [[AND {{county}}]]
 ),
 ranked AS (
     SELECT partner, count(*) AS screeners

--- a/dbt/models/postgres/intermediate/int_householdmembers.sql
+++ b/dbt/models/postgres/intermediate/int_householdmembers.sql
@@ -7,6 +7,7 @@ SELECT
     d.id AS screener_id,
     d.white_label_id,
     d.partner,
+    d.county,
     d.submission_date,
     sh.id,
     sh.age,

--- a/dbt/models/postgres/intermediate/int_immediate_needs.sql
+++ b/dbt/models/postgres/intermediate/int_immediate_needs.sql
@@ -6,6 +6,7 @@
 SELECT
     white_label_id,
     partner,
+    county,
     sum(CASE WHEN needs_baby_supplies = TRUE THEN 1 ELSE 0 END) AS needs_baby_supplies,
     sum(CASE WHEN needs_child_dev_help = TRUE THEN 1 ELSE 0 END) AS needs_child_dev_help,
     sum(CASE WHEN needs_food = TRUE THEN 1 ELSE 0 END) AS needs_food,
@@ -19,4 +20,4 @@ SELECT
     sum(CASE WHEN needs_college_savings = TRUE THEN 1 ELSE 0 END) AS needs_college_savings,
     sum(CASE WHEN needs_veteran_services = TRUE THEN 1 ELSE 0 END) AS needs_veteran_services
 FROM {{ ref('int_complete_screener_data') }}
-GROUP BY white_label_id, partner
+GROUP BY white_label_id, partner, county

--- a/dbt/models/postgres/intermediate/int_immediate_needs_unpivoted.sql
+++ b/dbt/models/postgres/intermediate/int_immediate_needs_unpivoted.sql
@@ -7,7 +7,8 @@ SELECT
     t.benefit,
     t.count,
     inb.white_label_id,
-    inb.partner
+    inb.partner,
+    inb.county
 FROM {{ ref('int_immediate_needs') }} AS inb
 CROSS JOIN LATERAL unnest(
     ARRAY[

--- a/dbt/models/postgres/intermediate/int_previous_benefits.sql
+++ b/dbt/models/postgres/intermediate/int_previous_benefits.sql
@@ -7,6 +7,7 @@
 SELECT
     white_label_id,
     partner,
+    county,
     sum(CASE WHEN has_acp = TRUE THEN 1 ELSE 0 END) AS acp,
     sum(CASE WHEN has_andcs = TRUE THEN 1 ELSE 0 END) AS andcs,
     sum(CASE WHEN has_ccb = TRUE THEN 1 ELSE 0 END) AS ccb,
@@ -56,4 +57,4 @@ SELECT
     sum(CASE WHEN has_va = TRUE THEN 1 ELSE 0 END) AS va,
     sum(CASE WHEN has_wic = TRUE THEN 1 ELSE 0 END) AS wic
 FROM {{ ref('int_complete_screener_data') }}
-GROUP BY white_label_id, partner
+GROUP BY white_label_id, partner, county

--- a/dbt/models/postgres/marts/mart_householdmembers.yml
+++ b/dbt/models/postgres/marts/mart_householdmembers.yml
@@ -25,6 +25,9 @@ models:
         tests:
           - not_null
 
+      - name: county
+        description: "County of the head of household."
+
       - name: screen_id
         description: "ID of the screener same as screener_id."
         tests:

--- a/dbt/models/postgres/marts/mart_previous_benefits.sql
+++ b/dbt/models/postgres/marts/mart_previous_benefits.sql
@@ -10,7 +10,8 @@ SELECT
     t.benefit,
     t.count,
     pb.white_label_id,
-    pb.partner
+    pb.partner,
+    pb.county
 FROM {{ ref('int_previous_benefits') }} AS pb
 CROSS JOIN LATERAL unnest(
     ARRAY[

--- a/dbt/models/postgres/marts/mart_qualified_benefits.sql
+++ b/dbt/models/postgres/marts/mart_qualified_benefits.sql
@@ -10,6 +10,7 @@ WITH base AS (
     SELECT
         white_label_id,
         partner,
+        county,
         sum(CASE WHEN lifeline_annual > 0 THEN 1 ELSE 0 END) AS lifeline,
         sum(CASE WHEN snap_annual > 0 THEN 1 ELSE 0 END) AS snap,
         sum(CASE WHEN co_snap_annual > 0 THEN 1 ELSE 0 END) AS co_snap,
@@ -123,14 +124,15 @@ WITH base AS (
         sum(CASE WHEN co_energy_calculator_xceleap_annual > 0 THEN 1 ELSE 0 END) AS co_xceleap,
         sum(CASE WHEN co_energy_calculator_xcelgap_annual > 0 THEN 1 ELSE 0 END) AS co_xcelgap
     FROM {{ ref('mart_screener_data') }}
-    GROUP BY 1, 2
+    GROUP BY 1, 2, 3
 )
 
 SELECT
     t.benefit,
     t.count,
     b.white_label_id,
-    b.partner
+    b.partner,
+    b.county
 FROM base AS b
 CROSS JOIN LATERAL unnest(
     ARRAY['Lifeline', 'SNAP', 'CO SNAP', 'NC SNAP', 'IL SNAP', 'MA SNAP', 'WIC', 'CO WIC', 'NC WIC', 'IL WIC', 'MA WIC', 'TANF', 'CO TANF', 'NC TANF', 'IL TANF', 'MA TAFDC', 'Medicaid', 'CO Medicaid', 'NC Medicaid', 'IL Medicaid', 'MA Mass Health', 'MA Mass Health Limited', 'NC Emergency Medicaid', 'Emergency Medicaid', 'AWD Medicaid', 'CWD Medicaid', 'Medicare Savings', 'NC SCCA', 'NC LIEAP', 'NCCIP', 'NC ACA', 'NC WAP', 'SSI', 'SSDI', 'NSLP', 'IL NSLP', 'EITC', 'CO EITC', 'IL EITC', 'MA EITC', 'CTC', 'CO CTC', 'IL CTC', 'FATC', 'SHITC', 'TABOR', 'OAP', 'Sunbucks', 'LEAP', 'ACP', 'CCAP', 'Pell Grant', 'ERAP', 'ANDCS', 'BCA', 'CDHCS', 'CFHC', 'CHP', 'CHS', 'CO CB', 'CO WAP', 'CPCR', 'DPP', 'DPTR', 'DSR', 'DTR', 'EDE', 'ERC', 'FPS', 'LWCR', 'MA ACA', 'MA CCDF', 'MA CFC', 'MA EAEDC', 'MA MBTA', 'MA SSP', 'My Denver', 'My Spark', 'NF', 'NFP', 'Omnisalud', 'RAG', 'RHC', 'RTD Live', 'TRUA', 'UBP', 'UPK', 'IL AABD', 'IL ACA', 'IL ACA Adults', 'IL All Kids', 'IL BAP', 'IL Family Care', 'IL LIHEAP', 'IL Moms and Babies', 'IL Transit Reduced Fare', 'CO BHEAP', 'CO BHGAP', 'CO CARE', 'CO CNGBA', 'CO WAP (Energy)', 'CO CPCR (Energy)', 'CO EA', 'CO Energy EBT', 'CO EOC', 'CO EOCCIP', 'CO EOCS', 'CO LEAP (Energy)', 'CO POIPP', 'CO UBP (Energy)', 'CO XCELEAP', 'CO XCELGAP'],


### PR DESCRIPTION
## Summary
- Adds a **County** dropdown filter alongside the existing Partner filter on every tenant dashboard tab
- Generalizes field ID lookup script to resolve both `partner` and `county` Metabase field IDs in a single API call
- Creates a `tenant_county_values` helper card per tenant for the dropdown values
- Adds `[[AND {{county}}]]` to all card SQL queries (inline and external `.sql` files)
- Updates global cards to strip both partner and county clauses
- Adds `county` to the GROUP BY in aggregate dbt models (`int_previous_benefits`, `int_immediate_needs`, `mart_qualified_benefits`) so materialized tables include county-level granularity
- Rewrites dashboard SQL for aggregate/household table cards to use a `filter_keys` CTE + INNER JOIN pattern, fixing Metabase dimension template tags generating table-qualified column references that fail against non-`mart_screener_data` tables

## Test plan
- [x] `terraform plan` — 7 to add (county helper cards), 252 to change, 0 to destroy
- [x] `terraform apply` — applied successfully on local Metabase
- [x] Verified County filter dropdown appears on each dashboard tab
- [x] `dbt run` — PASS=31, WARN=0, ERROR=0
- [x] Colorado dashboard with County=Denver County:
  - [x] Benefits & Immediate Needs tab: all 3 table cards load with filtered data
  - [x] Households tab: both age distribution charts load with filtered data
  - [x] All other tabs continue working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * County-level filtering added across analytics dashboards alongside existing partner filter.
  * New county dropdown parameter added to tenant benefits, households, and 30-day views; values populate dynamically.
  * Dashboards, metrics, tables, and visualizations now respect combined partner + county selections for accurate percentages, rankings, and distributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->