### PR TITLE
Added Youth Advisory Board code where relevant

### DIFF
--- a/data-queries/data_referrer_codes.sql
+++ b/data-queries/data_referrer_codes.sql
@@ -124,6 +124,7 @@ FROM (
     ('govdelivery', 'Other'),
     ('hello', 'Other'),
     ('hs_automation', 'Other'),
-    ('neighbor', 'Other')
+    ('neighbor', 'Other'),
+    ('yab', 'Youth Advisory Board')
 
 ) AS data_referrer_codes (referrer_code, partner);

--- a/data-queries/data_referrer_codes.sql
+++ b/data-queries/data_referrer_codes.sql
@@ -118,6 +118,7 @@ FROM (
     ('waterstonechurch', 'Waterstone Church'),
     ('weAreDownHome', 'We Are Down Home'),
     ('wrcgso', 'Women''s Resource Center of Greensboro'),
+    ('yab', 'Youth Advisory Board'),
     -- Could not match the following referrer codes to a partner:
     ('Sailthru', 'Other'),
     ('cgeneralprint', 'Other'),
@@ -125,6 +126,5 @@ FROM (
     ('hello', 'Other'),
     ('hs_automation', 'Other'),
     ('neighbor', 'Other'),
-    ('yab', 'Youth Advisory Board')
 
 ) AS data_referrer_codes (referrer_code, partner);

--- a/dbt/seeds/referrer_codes.csv
+++ b/dbt/seeds/referrer_codes.csv
@@ -117,3 +117,4 @@ govdelivery,Other
 hello,Other
 hs_automation,Other
 neighbor,Other
+yab,Youth Advisory Board

--- a/dbt/seeds/referrer_codes.csv
+++ b/dbt/seeds/referrer_codes.csv
@@ -111,10 +111,10 @@ villageExchange,Village Exchange
 waterstonechurch,Waterstone Church
 weAreDownHome,We Are Down Home
 wrcgso,Women's Resource Center of Greensboro
+yab,Youth Advisory Board
 Sailthru,Other
 cgeneralprint,Other
 govdelivery,Other
 hello,Other
 hs_automation,Other
 neighbor,Other
-yab,Youth Advisory Board


### PR DESCRIPTION
## Context & Motivation

Graciela needs a URL to provide Youth Advisory Board such that they can create QR code flyers with proper `referrer` tracking

## Changes Made

- `data_referrer_codes.sql`, added Youth Advisory Board with code
- `referrer_codes.csv`, added line for youth advisory board.

## Testing

There seems to be a load of tests in this repo but perhaps @catonph or @patwey have more insight here.

## Deployment

Again, will defer to teammates.

## Notes for Reviewers

This is my best guess at the changes required to add a new URL. If anything else comes to mind for this specific repo, please leave a comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Youth Advisory Board" (referrer code: yab) as a new selectable referrer option across the application.
  * This new code is included in reporting and lookup lists; existing referrer options and behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->