### PR TITLE
Implement Post slack Message with Materialized View Refresh Status.

### DIFF
--- a/.github/workflows/dbt-nightly.yml
+++ b/.github/workflows/dbt-nightly.yml
@@ -119,8 +119,10 @@ jobs:
           GCP_ANALYTICS_TABLE: ${{ vars.GCP_ANALYTICS_TABLE }}
       
       - name: Refresh materialized views
+        id: refresh_materialized_views
         run: |
           PGPASSWORD="$DB_PASS" psql \
+            -v ON_ERROR_STOP=1 \
             -h "$DB_HOST" \
             -U "$DB_USER" \
             -d "$DB_NAME" \
@@ -181,12 +183,12 @@ jobs:
       - name: Notify Slack
         if: always()
         run: |
-          STATUS="${{ job.status }}"
+          STATUS="${{ steps.refresh_materialized_views.outcome }}"
           ENV="${{ matrix.environment }}"
           if [ "$STATUS" = "success" ]; then
             MESSAGE="✅ *dbt + materialized view refresh succeeded* (${ENV}) — dashboards are up to date."
           else
-          MESSAGE="❌ *dbt + materialized view refresh failed* (${ENV}) — dashboards may be stale. See run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            MESSAGE="❌ *dbt + materialized view refresh failed* (${ENV}) — dashboards may be stale. See run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi
           curl -sf -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/dbt-nightly.yml
+++ b/.github/workflows/dbt-nightly.yml
@@ -117,7 +117,16 @@ jobs:
         env:
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           GCP_ANALYTICS_TABLE: ${{ vars.GCP_ANALYTICS_TABLE }}
+      
+      - name: Refresh materialized views
+        run: |
+          PGPASSWORD="$DB_PASS" psql \
+            -h "$DB_HOST" \
+            -U "$DB_USER" \
+            -d "$DB_NAME" \
+            -f ../data-queries/refresh_v1_dashboards.sql
 
+      
       - name: Trigger Metabase schema sync
         run: |
           METABASE_API="${METABASE_URL}/api"
@@ -168,3 +177,20 @@ jobs:
             dbt/target/manifest.json
             dbt/target/run_results.json
           retention-days: 7
+
+      - name: Notify Slack
+        if: always()
+        run: |
+          STATUS="${{ job.status }}"
+          ENV="${{ matrix.environment }}"
+          if [ "$STATUS" = "success" ]; then
+            MESSAGE="✅ *dbt + materialized view refresh succeeded* (${ENV}) — dashboards are up to date."
+          else
+          MESSAGE="❌ *dbt + materialized view refresh failed* (${ENV}) — dashboards may be stale. See run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi
+          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "{\"text\": \"${MESSAGE}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes #[MFB-424](https://linear.app/myfriendben/issue/MFB-424/data-post-slack-message-with-materialized-view-refresh-status)
- Related PR: None

The nightly dbt pipeline runs silently — when materialized view refreshes fail or data is stale, there's no visibility until someone notices a broken dashboard. This change adds automated Slack notifications so the team is alerted immediately on success or failure after each run.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->
<!-- Examples: dbt models added/modified, Terraform resources updated, Metabase container change, scripts added -->

- Added "Refresh materialized views" step to dbt-nightly.yml — runs refresh_v1_dashboards.sql via psql after the dbt build and before the Metabase schema sync
- Added "Notify Slack" step to dbt-nightly.yml — posts a success or failure message to Slack after every run using if: always() so it fires regardless of whether earlier steps passed or failed

- ...

## Testing

<!-- Steps needed to test this PR locally -->

- dbt models to run: no dbt model changes
- Terraform plan reviewed: N/A
- Local Metabase tested via docker-compose: yes / no / N/A
- Other manual testing steps: Not yet tested — `SLACK_WEBHOOK_URL` secret has not been added to GitHub environments (staging + production) yet. Full end-to-end test will be done once the Slack webhook is created and the secret is configured. The workflow will error on the Notify Slack step until then.

## Deployment

<!--
Merging to main automatically applies Terraform changes to Staging.
Production Terraform and Metabase container deployments require manual steps — note them here.
-->

- [ ] Production Terraform apply needed: no
- [ ] Metabase container rebuild/redeploy needed:  no
- [ ] dbt production run needed (outside nightly cron):  no
- [ ] Other post-deployment steps: Add SLACK_WEBHOOK_URL secret to both staging and production GitHub environments before this is fully functional

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations: The Slack notifications steps will fail on workflow runs until `SLACK_WEBHOOK_URL` is added as a GitHub secret -- this is expected and intentional. The dbt build and materialized view refresh steps are unaffected
- Future considerations: Could extend the slack message to include a summary of how many materialized views were refreshed or which ones failed individually 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now refreshes materialized views automatically after build completion to ensure dashboards reflect the latest data.
  * Added notifications to report refresh job results (success/failure) and indicate the deployment environment for clearer, real-time status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->