### PR TITLE
Add mart_referrer_codes with RLS for partner dropdown

### DIFF
--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -427,7 +427,7 @@ resource "metabase_card" "tenant_partner_values" {
     dataset_query = {
       type     = "native"
       database = tonumber(metabase_database.tenant_postgres[each.key].id)
-      native   = { query = "SELECT DISTINCT m.partner FROM analytics.mart_screener_data m JOIN public.screener_whitelabel wl ON m.white_label_id = wl.id WHERE m.partner IS NOT NULL AND wl.code = '${each.key}' UNION SELECT DISTINCT partner FROM analytics_internal.stg_referrer_codes WHERE (white_label_code = '${each.key}' OR white_label_code IS NULL OR white_label_code = '') AND partner IS NOT NULL AND partner <> 'No Partner' ORDER BY partner" }
+      native   = { query = "SELECT DISTINCT m.partner FROM analytics.mart_screener_data m JOIN public.screener_whitelabel wl ON m.white_label_id = wl.id WHERE m.partner IS NOT NULL AND wl.code = '${each.key}' UNION SELECT DISTINCT partner FROM analytics.mart_referrer_codes WHERE partner IS NOT NULL AND partner <> 'No Partner' ORDER BY partner" }
     }
   }))
 }

--- a/dbt/models/postgres/marts/mart_referrer_codes.sql
+++ b/dbt/models/postgres/marts/mart_referrer_codes.sql
@@ -1,0 +1,29 @@
+{{
+  config(
+    materialized='table',
+    description='Referrer codes with partner names, expanded per white label. Generic codes (null white_label_code) are duplicated for each WL. Used by Metabase partner dropdown filters.',
+    post_hook="{{ setup_white_label_rls(this.name) }}"
+  )
+}}
+
+-- WL-specific referrer codes: join to get white_label_id
+SELECT
+  rc.referrer_code,
+  rc.partner,
+  wl.white_label_id,
+  wl.white_label_code
+FROM {{ ref('stg_referrer_codes') }} rc
+INNER JOIN {{ ref('stg_white_label') }} wl
+  ON rc.white_label_code = wl.white_label_code
+
+UNION ALL
+
+-- Generic codes (null/empty WL): duplicate for every WL
+SELECT
+  rc.referrer_code,
+  rc.partner,
+  wl.white_label_id,
+  wl.white_label_code
+FROM {{ ref('stg_referrer_codes') }} rc
+CROSS JOIN {{ ref('stg_white_label') }} wl
+WHERE rc.white_label_code IS NULL OR rc.white_label_code = ''


### PR DESCRIPTION
## Summary
- Adds `mart_referrer_codes` table in `analytics` schema with standard RLS post-hook
- Generic referrer codes (friend, merit, other, etc.) are expanded per-WL via CROSS JOIN so each tenant only sees their relevant partners through RLS
- Updates Metabase partner dropdown query to use `analytics.mart_referrer_codes` instead of `analytics_internal.stg_referrer_codes`
- Eliminates the need for tenant DB users to have `analytics_internal` schema access

## Why
The previous approach referenced `analytics_internal.stg_referrer_codes` directly from Metabase, but tenant DB users don't have access to the `analytics_internal` schema (only `analytics`). This caused the seed union half of the dropdown query to silently return nothing.

## Test plan
- [ ] `dbt run --select mart_referrer_codes` creates table in `analytics` schema
- [ ] RLS works: TX tenant sees TX + generic partners only, CO sees CO + generic only
- [ ] Metabase partner dropdown shows correct WL-scoped partners
- [ ] No `analytics_internal` schema grants needed for tenant users

## Deploy order
1. dbt build (with `--full-refresh` if seed table schema changed)
2. Terraform apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)