### PR TITLE
Step 3b — dbt: Add stg_current_benefits staging model (data-queries)

### DIFF
--- a/dbt/models/postgres/sources.yml
+++ b/dbt/models/postgres/sources.yml
@@ -100,10 +100,33 @@ sources:
         columns:
           - name: id
             description: "Primary key"
+          - name: name_abbreviated
+            description: "Abbreviated program name (slug)"
           - name: value_type_id
             description: "Foreign key to translations_translation for the value type"
           - name: white_label_id
             description: "White label organization ID for RLS"
+      - name: screener_current_benefits
+        description: "Join table recording which programs a household currently receives at screen time"
+        columns:
+          - name: id
+            description: "Primary key"
+          - name: screen_id
+            description: "Foreign key to screener_screen"
+            tests:
+              - not_null
+              - relationships:
+                  arguments:
+                    field: id
+                    to: source('django_apps', 'screener_screen')
+          - name: program_id
+            description: "Foreign key to programs_program"
+            tests:
+              - not_null
+              - relationships:
+                  arguments:
+                    field: id
+                    to: source('django_apps', 'programs_program')
       - name: screener_incomestream
         description: "Income stream records from Django IncomeStream model"
         columns:

--- a/dbt/models/postgres/staging/schema.yml
+++ b/dbt/models/postgres/staging/schema.yml
@@ -1,6 +1,22 @@
 version: 2
 
 models:
+  - name: stg_current_benefits
+    description: "One row per screen × benefit. Joins screener_current_benefits to programs_program to resolve the abbreviated program name."
+    columns:
+      - name: screen_id
+        description: "Foreign key to screener_screen — identifies the screener submission"
+        tests:
+          - not_null
+      - name: program_id
+        description: "Foreign key to programs_program — identifies the benefit program"
+        tests:
+          - not_null
+      - name: benefit_name
+        description: "Abbreviated program name from programs_program.name_abbreviated"
+        tests:
+          - not_null
+
   - name: stg_referrer_codes
     description: "This model maps referrer codes to partner names."
     columns:

--- a/dbt/models/postgres/staging/schema.yml
+++ b/dbt/models/postgres/staging/schema.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: stg_current_benefits
-    description: "One row per screen × benefit. Thin, direct representation of screener_current_benefits. Downstream mart models join to programs_program directly for any program attributes they need."
+    description: "One row per screen × benefit. Thin, direct representation of screener_current_benefits."
     columns:
       - name: screen_id
         description: "Foreign key to screener_screen — identifies the screener submission"

--- a/dbt/models/postgres/staging/schema.yml
+++ b/dbt/models/postgres/staging/schema.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: stg_current_benefits
-    description: "One row per screen × benefit. Joins screener_current_benefits to programs_program to resolve the abbreviated program name."
+    description: "One row per screen × benefit. Thin, direct representation of screener_current_benefits. Downstream mart models join to programs_program directly for any program attributes they need."
     columns:
       - name: screen_id
         description: "Foreign key to screener_screen — identifies the screener submission"
@@ -10,10 +10,6 @@ models:
           - not_null
       - name: program_id
         description: "Foreign key to programs_program — identifies the benefit program"
-        tests:
-          - not_null
-      - name: benefit_name
-        description: "Abbreviated program name from programs_program.name_abbreviated"
         tests:
           - not_null
 

--- a/dbt/models/postgres/staging/stg_current_benefits.sql
+++ b/dbt/models/postgres/staging/stg_current_benefits.sql
@@ -1,14 +1,11 @@
 {{
   config(
     materialized='view',
-    description='One row per screen × benefit: joins screener_current_benefits to programs_program to resolve the abbreviated program name'
+    description='One row per screen × benefit: thin representation of screener_current_benefits'
   )
 }}
 
 SELECT
-    cb.screen_id,
-    cb.program_id,
-    pp.name_abbreviated AS benefit_name
-FROM {{ source('django_apps', 'screener_current_benefits') }} AS cb
-INNER JOIN {{ source('django_apps', 'programs_program') }} AS pp
-    ON cb.program_id = pp.id
+    screen_id,
+    program_id
+FROM {{ source('django_apps', 'screener_current_benefits') }}

--- a/dbt/models/postgres/staging/stg_current_benefits.sql
+++ b/dbt/models/postgres/staging/stg_current_benefits.sql
@@ -1,0 +1,14 @@
+{{
+  config(
+    materialized='view',
+    description='One row per screen × benefit: joins screener_current_benefits to programs_program to resolve the abbreviated program name'
+  )
+}}
+
+SELECT
+    cb.screen_id,
+    cb.program_id,
+    pp.name_abbreviated AS benefit_name
+FROM {{ source('django_apps', 'screener_current_benefits') }} AS cb
+INNER JOIN {{ source('django_apps', 'programs_program') }} AS pp
+    ON cb.program_id = pp.id


### PR DESCRIPTION
## Context & Motivation

- Fixes #[MFB-866](https://linear.app/myfriendben/issue/MFB-866/step-3b-dbt-add-stg-current-benefits-staging-model-data-queries)

## Changes Made

- Added stg_current_benefits dbt staging model ([stg_current_benefits.sql](vscode-file://vscode-app/c:/Users/irica/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) — materialized as a view; thin, direct representation of screener_current_benefits producing one row per screen × benefit (screen_id, program_id). Downstream mart models join to programs_program directly for any program attributes they need.
- Added model documentation and column-level not_null tests to [schema.yml](vscode-file://vscode-app/c:/Users/irica/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for stg_current_benefits (screen_id, program_id)
- Updated [sources.yml](vscode-file://vscode-app/c:/Users/irica/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
1. Added name_abbreviated column description to programs_program source
2. Added new screener_current_benefits source table with column descriptions and referential integrity tests (relationships) on screen_id → screener_screen and program_id → programs_program

<img width="553" height="287" alt="image" src="https://github.com/user-attachments/assets/50b89789-c079-4110-bd20-99a4de8225fa" />

## Testing

- dbt models to run: `dbt run --select stg_current_benefits`
- Terraform plan reviewed: N/A
- Local Metabase tested via docker-compose: N/A
- Other manual testing steps: dbt build --select stg_current_benefits to run model + tests together

## Deployment

-  Production Terraform apply needed: no
-  Metabase container rebuild/redeploy needed: no
-  dbt production run needed (outside nightly cron): no
-  Other post-deployment steps: N/A

## Notes for Reviewers

- Keeping stg_current_benefits as a thin staging model per reviewer feedback — no join to programs_program, no benefit_name column. Downstream mart models will resolve program attributes (e.g. name_abbreviated, display name, white_label_id) as needed.
- Known limitations: none at this layer
- Future considerations: downstream marts consuming this model should join programs_program directly for any program metadata
