### PR TITLE
fix: add id-token:write permission to dbt-on-merge workflow

### DIFF
--- a/.github/workflows/dbt-on-merge.yml
+++ b/.github/workflows/dbt-on-merge.yml
@@ -12,6 +12,9 @@ jobs:
   dbt-build:
     runs-on: ubuntu-latest
     environment: staging
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: dbt


### PR DESCRIPTION
## Summary
- Adds `id-token: write` permission to the `dbt-build` job so GCP Workload Identity Federation can inject the OIDC token
- The workflow has been failing on every run since it was created on April 8 — this is the only blocker
- Mirrors the permission block already present and working in `dbt-nightly.yml`

## Impact
Merges to `main` touching `dbt/` have not triggered a successful staging rebuild since April 8. Once this merges, the workflow will run and catch up on the latest state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)