### PR TITLE
Add TX programs to dbt benefit aggregation (hotfix)

### DIFF
--- a/dbt/models/postgres/intermediate/int_complete_screener_data.sql
+++ b/dbt/models/postgres/intermediate/int_complete_screener_data.sql
@@ -520,7 +520,33 @@ base_table_2 AS (
         + coalesce(cesn_poipp_annual, 0)
         + coalesce(cesn_ubp_annual, 0)
         + coalesce(cesn_xceleap_annual, 0)
-        + coalesce(cesn_xcelgap_annual, 0) AS non_tax_credit_benefits_annual,
+        + coalesce(cesn_xcelgap_annual, 0)
+        -- Texas programs
+        + coalesce(tx_aca_annual, 0)
+        + coalesce(tx_ccad_annual, 0)
+        + coalesce(tx_ccs_annual, 0)
+        + coalesce(tx_chip_annual, 0)
+        + coalesce(tx_csfp_annual, 0)
+        + coalesce(tx_dart_annual, 0)
+        + coalesce(tx_early_head_start_annual, 0)
+        + coalesce(tx_emergency_medicaid_annual, 0)
+        + coalesce(tx_fpp_annual, 0)
+        + coalesce(tx_harris_rides_annual, 0)
+        + coalesce(tx_head_start_annual, 0)
+        + coalesce(tx_hse_annual, 0)
+        + coalesce(tx_lifeline_annual, 0)
+        + coalesce(tx_medicaid_for_children_annual, 0)
+        + coalesce(tx_medicaid_for_parents_and_caretakers_annual, 0)
+        + coalesce(tx_medicaid_for_pregnant_women_annual, 0)
+        + coalesce(tx_medicare_savings_program_annual, 0)
+        + coalesce(tx_nslp_annual, 0)
+        + coalesce(tx_snap_annual, 0)
+        + coalesce(tx_ssi_annual, 0)
+        + coalesce(tx_ssdi_annual, 0)
+        + coalesce(tx_tanf_annual, 0)
+        + coalesce(tx_wap_annual, 0)
+        + coalesce(tx_wic_annual, 0)
+        + coalesce(trump_account_annual, 0) AS non_tax_credit_benefits_annual,
 
         -- Calculate tax credits total
         coalesce(coctc_annual, 0)
@@ -531,7 +557,10 @@ base_table_2 AS (
         + coalesce(il_ctc_annual, 0)
         + coalesce(il_eitc_annual, 0)
         + coalesce(ma_maeitc_annual, 0)
-        + coalesce(shitc_annual, 0) AS tax_credits_annual
+        + coalesce(shitc_annual, 0)
+        -- Texas tax credits
+        + coalesce(tx_ctc_annual, 0)
+        + coalesce(tx_eitc_annual, 0) AS tax_credits_annual
 
     FROM base_table_1
 )

--- a/dbt/models/postgres/staging/stg_program_eligibility.sql
+++ b/dbt/models/postgres/staging/stg_program_eligibility.sql
@@ -130,7 +130,35 @@ SELECT
     sum(CASE WHEN name_abbreviated = 'cesn_poipp' THEN estimated_value ELSE 0 END) AS cesn_poipp_annual,
     sum(CASE WHEN name_abbreviated = 'cesn_ubp' THEN estimated_value ELSE 0 END) AS cesn_ubp_annual,
     sum(CASE WHEN name_abbreviated = 'cesn_xceleap' THEN estimated_value ELSE 0 END) AS cesn_xceleap_annual,
-    sum(CASE WHEN name_abbreviated = 'cesn_xcelgap' THEN estimated_value ELSE 0 END) AS cesn_xcelgap_annual
+    sum(CASE WHEN name_abbreviated = 'cesn_xcelgap' THEN estimated_value ELSE 0 END) AS cesn_xcelgap_annual,
+    -- Texas programs
+    sum(CASE WHEN name_abbreviated = 'tx_aca' THEN estimated_value ELSE 0 END) AS tx_aca_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_ccad' THEN estimated_value ELSE 0 END) AS tx_ccad_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_ccs' THEN estimated_value ELSE 0 END) AS tx_ccs_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_chip' THEN estimated_value ELSE 0 END) AS tx_chip_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_csfp' THEN estimated_value ELSE 0 END) AS tx_csfp_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_ctc' THEN estimated_value ELSE 0 END) AS tx_ctc_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_dart' THEN estimated_value ELSE 0 END) AS tx_dart_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_early_head_start' THEN estimated_value ELSE 0 END) AS tx_early_head_start_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_eitc' THEN estimated_value ELSE 0 END) AS tx_eitc_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_emergency_medicaid' THEN estimated_value ELSE 0 END) AS tx_emergency_medicaid_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_fpp' THEN estimated_value ELSE 0 END) AS tx_fpp_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_harris_rides' THEN estimated_value ELSE 0 END) AS tx_harris_rides_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_head_start' THEN estimated_value ELSE 0 END) AS tx_head_start_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_hse' THEN estimated_value ELSE 0 END) AS tx_hse_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_lifeline' THEN estimated_value ELSE 0 END) AS tx_lifeline_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_medicaid_for_children' THEN estimated_value ELSE 0 END) AS tx_medicaid_for_children_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_medicaid_for_parents_and_caretakers' THEN estimated_value ELSE 0 END) AS tx_medicaid_for_parents_and_caretakers_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_medicaid_for_pregnant_women' THEN estimated_value ELSE 0 END) AS tx_medicaid_for_pregnant_women_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_medicare_savings_program' THEN estimated_value ELSE 0 END) AS tx_medicare_savings_program_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_nslp' THEN estimated_value ELSE 0 END) AS tx_nslp_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_snap' THEN estimated_value ELSE 0 END) AS tx_snap_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_ssi' THEN estimated_value ELSE 0 END) AS tx_ssi_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_ssdi' THEN estimated_value ELSE 0 END) AS tx_ssdi_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_tanf' THEN estimated_value ELSE 0 END) AS tx_tanf_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_wap' THEN estimated_value ELSE 0 END) AS tx_wap_annual,
+    sum(CASE WHEN name_abbreviated = 'tx_wic' THEN estimated_value ELSE 0 END) AS tx_wic_annual,
+    sum(CASE WHEN name_abbreviated = 'trump_account' THEN estimated_value ELSE 0 END) AS trump_account_annual
 FROM {{ source('django_apps', 'screener_programeligibilitysnapshot') }}
 WHERE eligible = TRUE
 GROUP BY eligibility_snapshot_id

--- a/dbt/models/postgres/staging/stg_program_eligibility.sql
+++ b/dbt/models/postgres/staging/stg_program_eligibility.sql
@@ -139,18 +139,34 @@ SELECT
     sum(CASE WHEN name_abbreviated = 'tx_csfp' THEN estimated_value ELSE 0 END) AS tx_csfp_annual,
     sum(CASE WHEN name_abbreviated = 'tx_ctc' THEN estimated_value ELSE 0 END) AS tx_ctc_annual,
     sum(CASE WHEN name_abbreviated = 'tx_dart' THEN estimated_value ELSE 0 END) AS tx_dart_annual,
-    sum(CASE WHEN name_abbreviated = 'tx_early_head_start' THEN estimated_value ELSE 0 END) AS tx_early_head_start_annual,
+    sum(
+        CASE WHEN name_abbreviated = 'tx_early_head_start' THEN estimated_value ELSE 0 END
+    ) AS tx_early_head_start_annual,
     sum(CASE WHEN name_abbreviated = 'tx_eitc' THEN estimated_value ELSE 0 END) AS tx_eitc_annual,
-    sum(CASE WHEN name_abbreviated = 'tx_emergency_medicaid' THEN estimated_value ELSE 0 END) AS tx_emergency_medicaid_annual,
+    sum(
+        CASE WHEN name_abbreviated = 'tx_emergency_medicaid' THEN estimated_value ELSE 0 END
+    ) AS tx_emergency_medicaid_annual,
     sum(CASE WHEN name_abbreviated = 'tx_fpp' THEN estimated_value ELSE 0 END) AS tx_fpp_annual,
     sum(CASE WHEN name_abbreviated = 'tx_harris_rides' THEN estimated_value ELSE 0 END) AS tx_harris_rides_annual,
     sum(CASE WHEN name_abbreviated = 'tx_head_start' THEN estimated_value ELSE 0 END) AS tx_head_start_annual,
     sum(CASE WHEN name_abbreviated = 'tx_hse' THEN estimated_value ELSE 0 END) AS tx_hse_annual,
     sum(CASE WHEN name_abbreviated = 'tx_lifeline' THEN estimated_value ELSE 0 END) AS tx_lifeline_annual,
-    sum(CASE WHEN name_abbreviated = 'tx_medicaid_for_children' THEN estimated_value ELSE 0 END) AS tx_medicaid_for_children_annual,
-    sum(CASE WHEN name_abbreviated = 'tx_medicaid_for_parents_and_caretakers' THEN estimated_value ELSE 0 END) AS tx_medicaid_for_parents_and_caretakers_annual,
-    sum(CASE WHEN name_abbreviated = 'tx_medicaid_for_pregnant_women' THEN estimated_value ELSE 0 END) AS tx_medicaid_for_pregnant_women_annual,
-    sum(CASE WHEN name_abbreviated = 'tx_medicare_savings_program' THEN estimated_value ELSE 0 END) AS tx_medicare_savings_program_annual,
+    sum(
+        CASE WHEN name_abbreviated = 'tx_medicaid_for_children' THEN estimated_value ELSE 0 END
+    ) AS tx_medicaid_for_children_annual,
+    sum(
+        CASE
+            WHEN name_abbreviated = 'tx_medicaid_for_parents_and_caretakers'
+                THEN estimated_value
+            ELSE 0
+        END
+    ) AS tx_medicaid_for_parents_and_caretakers_annual,
+    sum(
+        CASE WHEN name_abbreviated = 'tx_medicaid_for_pregnant_women' THEN estimated_value ELSE 0 END
+    ) AS tx_medicaid_for_pregnant_women_annual,
+    sum(
+        CASE WHEN name_abbreviated = 'tx_medicare_savings_program' THEN estimated_value ELSE 0 END
+    ) AS tx_medicare_savings_program_annual,
     sum(CASE WHEN name_abbreviated = 'tx_nslp' THEN estimated_value ELSE 0 END) AS tx_nslp_annual,
     sum(CASE WHEN name_abbreviated = 'tx_snap' THEN estimated_value ELSE 0 END) AS tx_snap_annual,
     sum(CASE WHEN name_abbreviated = 'tx_ssi' THEN estimated_value ELSE 0 END) AS tx_ssi_annual,


### PR DESCRIPTION
## Summary

- TX programs all use a `tx_` prefix that was never added to the hardcoded program lists in `stg_program_eligibility` or `int_complete_screener_data`
- This caused the TX Metabase dashboard to show 0% qualified for benefits, 0% qualified for tax credits, and null medians despite 52 completed screeners
- Adds all 27 TX programs to `stg_program_eligibility` pivot and includes them in the `non_tax_credit_benefits_annual` and `tax_credits_annual` sums

## Note

This is a short-term hotfix. MFB-950 (#80) will supersede these changes entirely by replacing the hardcoded lists with dynamic aggregation. This PR should be merged before MFB-950, or MFB-950 should be merged first and this PR closed — do not merge both.

## Test plan

- [ ] Run `dbt run` and verify `analytics.mart_screener_data` rebuilds
- [ ] Confirm TX dashboard shows non-zero qualified % and median benefit values
- [ ] Verify query: `SELECT count(*) FILTER (WHERE non_tax_credit_benefits_annual > 0) FROM analytics.mart_screener_data WHERE white_label_id = (SELECT id FROM screener_whitelabel WHERE code = 'tx')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)