### PR TITLE
Add summary metrics for NC: Total Individuals, Total Benefits, Non-Tax Benefits, and Tax Benefits

### DIFF
--- a/dashboards/config_template.tf
+++ b/dashboards/config_template.tf
@@ -72,16 +72,19 @@ locals {
     "show_mini_bar" = true
   }
 
+  # Hierarchy note rendered next to the summary metric cards.
+  summary_metrics_note = "**Total Benefits** equals the sum of **Tax Benefits** and **Non-Tax Benefits**."
+
   # Per-tenant feature flags — controls which cards appear on shared dashboard tabs.
   # Add a new tenant here instead of scattering tenant-key conditionals across layout files.
   tenant_features = {
-    nc                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true }
-    co                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true }
-    tx                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true }
-    il                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true }
-    ma                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true }
-    cesn              = { has_tax_credits = false, has_immediate_needs = false, has_assets = false, has_expenses = false, has_partners = false }
-    co_tax_calculator = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true }
+    nc                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = true }
+    co                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false }
+    tx                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false }
+    il                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false }
+    ma                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false }
+    cesn              = { has_tax_credits = false, has_immediate_needs = false, has_assets = false, has_expenses = false, has_partners = false, has_summary_metrics = false }
+    co_tax_calculator = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false }
   }
 
   # All available dashboard tabs with fixed IDs — per tenant so names can vary

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -307,6 +307,91 @@ resource "metabase_card" "tenant_median_annual_tax_credits" {
   }))
 }
 
+# Tenant-specific summary metric: Total Individuals (sum of household_size)
+resource "metabase_card" "tenant_total_individuals" {
+  for_each = var.tenants
+
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Total Individuals"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT COALESCE(SUM(household_size), 0) AS total FROM analytics.mart_screener_data WHERE 1=1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
+      }
+    }
+    visualization_settings = { "scalar.field" = "total" }
+  }))
+}
+
+# Tenant-specific summary metric: Total Benefits (non-tax + tax annual)
+resource "metabase_card" "tenant_total_benefits" {
+  for_each = var.tenants
+
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Total Benefits"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT COALESCE(SUM(non_tax_credit_benefits_annual), 0) + COALESCE(SUM(tax_credits_annual), 0) AS total FROM analytics.mart_screener_data WHERE 1=1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "total"
+      "column_settings" = { "[\"name\",\"total\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+# Tenant-specific summary metric: Non-Tax Benefits (sum of non_tax_credit_benefits_annual)
+resource "metabase_card" "tenant_total_non_tax_benefits" {
+  for_each = var.tenants
+
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Non-Tax Benefits"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT COALESCE(SUM(non_tax_credit_benefits_annual), 0) AS total FROM analytics.mart_screener_data WHERE 1=1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "total"
+      "column_settings" = { "[\"name\",\"total\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
+# Tenant-specific summary metric: Tax Benefits (sum of tax_credits_annual)
+resource "metabase_card" "tenant_total_tax_benefits" {
+  for_each = var.tenants
+
+  json = jsonencode(merge(local.tenant_scorecard_config, {
+    name          = "Tax Benefits"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = "SELECT COALESCE(SUM(tax_credits_annual), 0) AS total FROM analytics.mart_screener_data WHERE 1=1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]"
+        "template-tags" = local.filter_template_tags[each.key]
+      }
+    }
+    visualization_settings = {
+      "scalar.field"    = "total"
+      "column_settings" = { "[\"name\",\"total\"]" = local.currency_format_0 }
+    }
+  }))
+}
+
 # Tenant-specific daily screeners bar chart (last 7 days)
 resource "metabase_card" "tenant_daily_screeners_7d" {
   for_each = var.tenants
@@ -930,8 +1015,9 @@ resource "metabase_dashboard" "tenant_analytics" {
     # Tab 1: Google Analytics
     local.tenant_has_tab[each.key]["google_analytics"] ? local.tenant_dashboard_ga_layout[each.key] : [],
     # Tab 2: Overall Performance
-    # flatten(concat(...)) lets us conditionally include CESN-excluded cards
-    local.tenant_has_tab[each.key]["households"] ? flatten(concat(
+    # Two for-loop flattens avoid Terraform's static ternary type-check
+    flatten([for k in [each.key] : flatten(concat(
+      # Row 0: Performance scorecards
       [
         {
           card_id          = tonumber(metabase_card.tenant_completed_screeners[each.key].id)
@@ -1101,11 +1187,148 @@ resource "metabase_dashboard" "tenant_analytics" {
           visualization_settings = {}
         },
       ] : [],
+      # Row 4: Summary metrics — TI (col 0) | Non-Tax (col 4) | Tax (col 8) | Total Benefits (col 12, 8×4) | Note (col 20).
+      # Keep cards ordered by (row, col) — terraform apply errors with "Provider produced inconsistent result" otherwise.
+      local.tenant_features[each.key].has_summary_metrics ? [
+        {
+          card_id          = tonumber(metabase_card.tenant_total_individuals[each.key].id)
+          dashboard_tab_id = 2
+          row              = 4
+          col              = 0
+          size_x           = local.alltime_scorecard_width[each.key]
+          size_y           = 4
+          parameter_mappings = [
+            {
+              parameter_id = "date_range_filter"
+              card_id      = tonumber(metabase_card.tenant_total_individuals[each.key].id)
+              target       = ["dimension", ["template-tag", "submission_date"]]
+            },
+            {
+              parameter_id = "partner_filter"
+              card_id      = tonumber(metabase_card.tenant_total_individuals[each.key].id)
+              target       = ["dimension", ["template-tag", "partner"]]
+            },
+            {
+              parameter_id = "county_filter"
+              card_id      = tonumber(metabase_card.tenant_total_individuals[each.key].id)
+              target       = ["dimension", ["template-tag", "county"]]
+            }
+          ]
+          series                 = []
+          visualization_settings = {}
+        },
+        {
+          card_id          = tonumber(metabase_card.tenant_total_non_tax_benefits[each.key].id)
+          dashboard_tab_id = 2
+          row              = 4
+          col              = local.alltime_scorecard_width[each.key]
+          size_x           = local.alltime_scorecard_width[each.key]
+          size_y           = 4
+          parameter_mappings = [
+            {
+              parameter_id = "date_range_filter"
+              card_id      = tonumber(metabase_card.tenant_total_non_tax_benefits[each.key].id)
+              target       = ["dimension", ["template-tag", "submission_date"]]
+            },
+            {
+              parameter_id = "partner_filter"
+              card_id      = tonumber(metabase_card.tenant_total_non_tax_benefits[each.key].id)
+              target       = ["dimension", ["template-tag", "partner"]]
+            },
+            {
+              parameter_id = "county_filter"
+              card_id      = tonumber(metabase_card.tenant_total_non_tax_benefits[each.key].id)
+              target       = ["dimension", ["template-tag", "county"]]
+            }
+          ]
+          series                 = []
+          visualization_settings = {}
+        },
+      ] : [],
+      local.tenant_features[each.key].has_summary_metrics && local.tenant_features[each.key].has_tax_credits ? [
+        {
+          card_id          = tonumber(metabase_card.tenant_total_tax_benefits[each.key].id)
+          dashboard_tab_id = 2
+          row              = 4
+          col              = 8
+          size_x           = 4
+          size_y           = 4
+          parameter_mappings = [
+            {
+              parameter_id = "date_range_filter"
+              card_id      = tonumber(metabase_card.tenant_total_tax_benefits[each.key].id)
+              target       = ["dimension", ["template-tag", "submission_date"]]
+            },
+            {
+              parameter_id = "partner_filter"
+              card_id      = tonumber(metabase_card.tenant_total_tax_benefits[each.key].id)
+              target       = ["dimension", ["template-tag", "partner"]]
+            },
+            {
+              parameter_id = "county_filter"
+              card_id      = tonumber(metabase_card.tenant_total_tax_benefits[each.key].id)
+              target       = ["dimension", ["template-tag", "county"]]
+            }
+          ]
+          series                 = []
+          visualization_settings = {}
+        },
+      ] : [],
+      local.tenant_features[each.key].has_summary_metrics && local.tenant_features[each.key].has_tax_credits ? [
+        {
+          card_id          = tonumber(metabase_card.tenant_total_benefits[each.key].id)
+          dashboard_tab_id = 2
+          row              = 4
+          col              = 12
+          size_x           = 8
+          size_y           = 4
+          parameter_mappings = [
+            {
+              parameter_id = "date_range_filter"
+              card_id      = tonumber(metabase_card.tenant_total_benefits[each.key].id)
+              target       = ["dimension", ["template-tag", "submission_date"]]
+            },
+            {
+              parameter_id = "partner_filter"
+              card_id      = tonumber(metabase_card.tenant_total_benefits[each.key].id)
+              target       = ["dimension", ["template-tag", "partner"]]
+            },
+            {
+              parameter_id = "county_filter"
+              card_id      = tonumber(metabase_card.tenant_total_benefits[each.key].id)
+              target       = ["dimension", ["template-tag", "county"]]
+            }
+          ]
+          series                 = []
+          visualization_settings = {}
+        },
+      ] : [],
+      local.tenant_features[each.key].has_summary_metrics && local.tenant_features[each.key].has_tax_credits ? [
+        {
+          card_id            = null
+          dashboard_tab_id   = 2
+          row                = 4
+          col                = 20
+          size_x             = 4
+          size_y             = 4
+          parameter_mappings = []
+          series             = []
+          visualization_settings = {
+            virtual_card = {
+              name                   = null
+              dataset_query          = {}
+              display                = "text"
+              visualization_settings = {}
+            }
+            text = local.summary_metrics_note
+          }
+        },
+      ] : [],
       [
         {
           card_id          = tonumber(metabase_card.tenant_daily_screeners_7d[each.key].id)
           dashboard_tab_id = 2
-          row              = 4
+          row              = local.tenant_features[each.key].has_summary_metrics ? 8 : 4
           col              = 0
           size_x           = 24
           size_y           = 6
@@ -1135,7 +1358,7 @@ resource "metabase_dashboard" "tenant_analytics" {
         {
           card_id          = tonumber(metabase_card.tenant_top_partners[each.key].id)
           dashboard_tab_id = 2
-          row              = 10
+          row              = local.tenant_features[each.key].has_summary_metrics ? 14 : 10
           col              = 0
           size_x           = 12
           size_y           = 8
@@ -1164,7 +1387,7 @@ resource "metabase_dashboard" "tenant_analytics" {
         {
           card_id          = tonumber(metabase_card.tenant_top_counties[each.key].id)
           dashboard_tab_id = 2
-          row              = 10
+          row              = local.tenant_features[each.key].has_summary_metrics ? 14 : 10
           col              = local.tenant_features[each.key].has_partners ? 12 : 0
           size_x           = local.tenant_features[each.key].has_partners ? 12 : 24
           size_y           = 8
@@ -1189,9 +1412,11 @@ resource "metabase_dashboard" "tenant_analytics" {
           visualization_settings = {}
         },
       ],
-      )) : [
+    )) if local.tenant_has_tab[k]["households"]]),
+    # Tab 2: fallback for tenants without the households tab
+    flatten([for k in [each.key] : [
       {
-        card_id                = tonumber(metabase_card.tenant_screen_count[each.key].id)
+        card_id                = tonumber(metabase_card.tenant_screen_count[k].id)
         dashboard_tab_id       = 2
         row                    = 0
         col                    = 0
@@ -1201,7 +1426,7 @@ resource "metabase_dashboard" "tenant_analytics" {
         series                 = []
         visualization_settings = {}
       }
-    ],
+    ] if !local.tenant_has_tab[k]["households"]]),
     # Tab 3: Households (flatten+for avoids the conditional type mismatch
     # between the mixed text/data tuple and an empty list)
     flatten([for k in [each.key] : local.tenant_dashboard_households_data_layout[k] if local.tenant_has_tab[k]["households"]]),


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes #[MFB-660](https://linear.app/myfriendben/issue/MFB-660/data-additional-summary-metrics-in-performance-tabs)

Adds summary metrics to the performance dashboard for NC.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->
<!-- Examples: dbt models added/modified, Terraform resources updated, Metabase container change, scripts added -->

- Added a `has_summary_metrics` flag in `dashboards/config_template.tf` (currently only turned on for `NC`).
- Created 4 new Metabase cards in `dashboards/metabase.tf`:
  - **Total Individuals** 
  - **Total Benefits**
  - **Non-Tax Benefits**
  - **Tax Benefits**
- Added a short note explaining how the benefit totals are calculated.
- Updated the dashboard layout to show these new cards when the flag is on.

## Testing

<!-- Steps needed to test this PR locally -->

- dbt models to run: N/A
- Terraform plan reviewed: <!-- paste or link to plan output if applicable -->
- Local Metabase tested via docker-compose: yes 
- Other manual testing steps:
Checked on local env that new cards are only created for NC and don't break other dashboards. 
<img width="1069" height="820" alt="Screen Shot 2026-04-29 at 3 07 08 PM" src="https://github.com/user-attachments/assets/7cfeb882-a7da-4405-ae7e-eb709e5e3240" />

New metrics are not shown for other states e.g. Colorado dashboard
<img width="1062" height="651" alt="Screen Shot 2026-04-29 at 3 55 33 PM" src="https://github.com/user-attachments/assets/8932b152-1c77-4af8-97ae-adf6e3a4422e" />

## Deployment

<!--
Merging to main automatically applies Terraform changes to Staging.
Production Terraform and Metabase container deployments require manual steps — note them here.
-->

- [x] Production Terraform apply needed: yes
- [ ] Metabase container rebuild/redeploy needed: no
- [ ] dbt production run needed (outside nightly cron): no
- [ ] Other post-deployment steps:

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations: Only the `nc` tenant has these metrics for now.
- Future considerations: We can turn this on for other tenants later by updating their flags in `config_template.tf`. If we decide to enable this for `cesn` (which does not have tax benefits), we will need to handle that edge case—likely by only adding 2 metrics instead of 4.
