### PR TITLE
MFB-974 : Fix what percentage of completed screeners qualified for benefits filter by WL

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -7,8 +7,9 @@ large_file_skip_byte_limit = 0
 processes = -1
 
 # Only format layout/style — disable semantic rules that require DB context
-# PRS excluded: Metabase [[ ]] optional filter syntax is not valid Jinja/SQL
-exclude_rules = AM04, AL01, AL05, RF01, RF02, RF03, RF04, RF05, CP02, ST06, PRS, JJ01
+exclude_rules = AM04, AL01, AL05, RF01, RF02, RF03, RF04, RF05, CP02, ST06, JJ01, LT01
+# Suppress parse/template errors from Metabase [[ ]] optional filter syntax (not valid Jinja/SQL)
+ignore = parsing, templating
 
 [sqlfluff:templater:jinja]
 # Provides ref(), source(), config(), var() etc. automatically
@@ -18,6 +19,7 @@ apply_dbt_builtins = True
 # Metabase optional filter variables — defined here so SQLFluff does not raise TMP errors
 submission_date = 1
 partner = 1
+county = 1
 
 [sqlfluff:rules:layout.indent]
 indent_unit = space

--- a/dashboards/sql/qualified_benefits.sql
+++ b/dashboards/sql/qualified_benefits.sql
@@ -1,15 +1,29 @@
 WITH totals AS (
-    SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]
+    SELECT count(*) AS total_count
+    FROM analytics.mart_screener_data
+    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]
 ),
+
 filter_keys AS (
-    SELECT DISTINCT partner, county FROM analytics.mart_screener_data WHERE 1=1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]
+    SELECT DISTINCT
+        white_label_id,
+        partner,
+        county
+    FROM analytics.mart_screener_data
+    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]
 )
+
 SELECT
-    qb.benefit as "Benefit Name",
-    SUM(qb.count) as "# of Screeners",
-    SUM(qb.count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
-FROM analytics.mart_qualified_benefits qb
-INNER JOIN filter_keys fk ON qb.partner IS NOT DISTINCT FROM fk.partner AND qb.county IS NOT DISTINCT FROM fk.county
-CROSS JOIN totals t
+    qb.benefit AS "Benefit Name",
+    sum(qb.count) AS "# of Screeners",
+    sum(qb.count)::FLOAT / nullif(max(t.total_count), 0) AS "% of Screeners"
+FROM analytics.mart_qualified_benefits AS qb
+INNER JOIN filter_keys AS fk
+    ON
+        qb.partner IS NOT DISTINCT FROM fk.partner
+        AND qb.county IS NOT DISTINCT FROM fk.county
+        AND qb.white_label_id = fk.white_label_id
+CROSS JOIN totals AS t
 GROUP BY qb.benefit
-ORDER BY SUM(qb.count) DESC, qb.benefit ASC
+HAVING sum(qb.count) > 0
+ORDER BY sum(qb.count) DESC, qb.benefit ASC


### PR DESCRIPTION

## Context & Motivation

- Fixes [MFB-974](https://linear.app/myfriendben/issue/MFB-974/metabase-what-benefits-screeners-qualified-for-filter-by-wl)

Previously, the "**What percentage of completed screeners qualified for benefits?**" table on the dashboards showed all programs from all states/White Labels at the same time.  This change ensures that each dashboard only displays the benefit programs that are relevant to its specific White Label.

## Changes Made

Added a White Label filter so each `Benefits & Immediate Needs` tab now only shows benefit programs relevant to its own state.

## Testing

Other manual testing steps:

1. Run `terraform init ` and `terraform apply`
2. Navigate to `Benefits & Immediate Needs` tab.
3. Verify that `What percentage of completed screeners qualified for benefits?` table ONLY returns programs that belong to its own state rather than listing all.

Before : 112 rows for MA
<img width="838" height="712" alt="Screenshot 2026-04-30 at 10 52 12 AM" src="https://github.com/user-attachments/assets/2cd541ec-7ea2-49b9-a208-d74e864a82cd" />

After fix: 12 rows
<img width="838" height="712" alt="Screenshot 2026-04-30 at 10 54 48 AM" src="https://github.com/user-attachments/assets/fc62f80d-ecac-4950-999e-2f73ca6d379b" />

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- Known limitations:
- Future considerations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL processing error handling to better support template and parsing operations, reducing configuration failures.

* **Refactor**
  * Enhanced qualified benefits dashboard query to refine filtering logic with additional criteria and exclude items with minimal activity from results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->