### PR TITLE
Fix metabase provider crash on schema-level permissions during terraform apply

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -33,26 +33,31 @@ Open http://localhost:3001 in your browser (or the URL shown by the setup script
 
 **3. Create tenant database users with row-level security**
 
-Each tenant needs a dedicated database role whose name encodes the `white_label_id`. RLS uses **username-based filtering** — the policy extracts the `white_label_id` from the connecting role's name via `regexp_match(current_user, '^wl_[a-z_]+_([0-9]+)_ro$')`. Only roles matching the `wl_<state>_<white_label_id>_ro` convention see their tenant's data; non-conforming roles get zero rows.
+Each tenant needs a dedicated database role whose name encodes the `white_label_id`. RLS uses **username-based filtering** — the policy extracts the `white_label_id` from the connecting role's name. Only roles matching the `wl_<state>_<white_label_id>_ro` convention see their tenant's data; non-conforming roles get zero rows.
 
 **Important:** Before running these commands:
 - Replace `white_label_id` values with the correct IDs from your MyFriendBen database
 - Update the database name (`mfb`) and credentials to match your local setup
 
 ```bash
+# Set password as environment variable (keeps it out of shell history)
+export DB_PASSWORD="secure_password"
+
 psql -h localhost -U postgres -d mfb << EOF
 -- Create role for North Carolina (white_label_id = 5)
-CREATE ROLE wl_nc_5_ro LOGIN;
+CREATE ROLE wl_nc_5_ro WITH LOGIN PASSWORD '$DB_PASSWORD';
 GRANT CONNECT ON DATABASE mfb TO wl_nc_5_ro;
 GRANT USAGE ON SCHEMA analytics TO wl_nc_5_ro;
 GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO wl_nc_5_ro;
 
 -- Create role for Colorado (white_label_id = 1)
-CREATE ROLE wl_co_1_ro LOGIN;
+CREATE ROLE wl_co_1_ro WITH LOGIN PASSWORD '$DB_PASSWORD';
 GRANT CONNECT ON DATABASE mfb TO wl_co_1_ro;
 GRANT USAGE ON SCHEMA analytics TO wl_co_1_ro;
 GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO wl_co_1_ro;
 EOF
+
+unset DB_PASSWORD
 ```
 
 **4. Configure Terraform variables**
@@ -80,7 +85,7 @@ terraform init
 
 # Step 2: Create databases, groups, collections, and cards.
 # This also triggers Metabase to sync schemas and create its built-in groups/objects.
-terraform apply
+terraform apply -auto-approve
 
 # Step 3: Import the permissions graph singleton into Terraform state.
 # (Must happen after apply so Metabase's default groups and databases exist.)
@@ -208,20 +213,25 @@ locals {
 
 > **Note on permissions:** The `metabase_permissions_group.tenant`, collection permission entries, and data permission entries in `permissions.tf` all use `for_each`/`for` over `var.tenants`, so the new group, its collection permissions, and its data source permissions are all created automatically. No changes to `permissions.tf` are needed.
 
-### 3. Create Database User
+### 3. Create Database Role
 
 Create a new database role with row-level security (see Quick Start step 3 for detailed instructions).
 
 **Note:** Check your MyFriendBen database to find the correct `white_label_id` for the new tenant.
 
 ```bash
+# Set password as environment variable (keeps it out of shell history)
+export DB_PASSWORD="secure_password"
+
 psql -h localhost -U postgres -d mfb << EOF
 -- Create role for Texas (white_label_id = 40)
-CREATE ROLE wl_tx_40_ro LOGIN;
+CREATE ROLE wl_tx_40_ro WITH LOGIN PASSWORD '$DB_PASSWORD';
 GRANT CONNECT ON DATABASE mfb TO wl_tx_40_ro;
 GRANT USAGE ON SCHEMA analytics TO wl_tx_40_ro;
 GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO wl_tx_40_ro;
 EOF
+
+unset DB_PASSWORD
 ```
 
 ### 4. Deploy New Tenant
@@ -309,6 +319,67 @@ Verify database user exists and has correct `white_label_id` setting
 ### Connection errors
 
 Check credentials in `terraform.tfvars`
+
+### Permissions graph: stale state (409)
+
+```
+Status code: 409, body: Looks like someone else edited the permissions and your data is out of date.
+```
+
+Terraform's cached state is behind Metabase's current revision (happens after manual UI changes). Re-import both graphs to get fresh state, then apply:
+
+```bash
+terraform state rm metabase_permissions_graph.graph
+terraform import metabase_permissions_graph.graph 1
+
+terraform state rm metabase_collection_graph.graph
+terraform import metabase_collection_graph.graph 1
+
+terraform apply
+```
+
+### Permissions graph: unmarshal crash
+
+```
+json: cannot unmarshal object into Go struct field PermissionsGraphDatabasePermissions.groups.create-queries
+```
+
+A group in Metabase has schema-level (per-schema) query permissions instead of a flat top-level value. This is a provider bug — the provider crashes reading that format.
+
+**Step 1: Identify the problem group**
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:3001/api/session \
+  -H "Content-Type: application/json" \
+  -d '{"username":"<admin_email>","password":"<password>"}' | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+
+curl -s http://localhost:3001/api/permissions/graph \
+  -H "X-Metabase-Session: $TOKEN" | python3 -m json.tool | grep -A3 "create-queries"
+```
+
+Look for a `create-queries` value that is an object `{}` rather than a plain string like `"query-builder"`.
+
+**Step 2: Fix it in the Metabase UI**
+
+Go to Admin → Permissions, find the group, and change its database query permission from schema-level to a top-level value (e.g. "Query builder only").
+
+> **Note:** The codebase includes a workaround that prevents this crash during initial `terraform apply`. However, `terraform import` still hits the provider bug directly — fixing the permissions in the UI (Step 2) is always required before running imports.
+
+**Step 3: Re-import and apply**
+
+```bash
+terraform state rm metabase_permissions_graph.graph
+terraform import metabase_permissions_graph.graph 1
+
+terraform state rm metabase_collection_graph.graph
+terraform import metabase_collection_graph.graph 1
+
+terraform apply
+```
+
+**Notes:** 
+- If you see a 400 `nil view-data` error during `terraform apply` after a manually created group exists in Metabase, delete that group from the Metabase UI and re-run apply. This is a provider bug where `ignored_groups` does not correctly preserve unmanaged group permissions during write operations.
+- **Never use `terraform destroy` in staging or production.** It deletes all dashboards, cards, collections, and groups — breaking existing user bookmarks, saved URLs, and any manual UI configuration not managed by Terraform. For staging/production, always use the surgical approach: fix the issue in the Metabase UI, re-import affected resources, and run `terraform apply`.
 
 ### Switching Branches
 

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -33,33 +33,26 @@ Open http://localhost:3001 in your browser (or the URL shown by the setup script
 
 **3. Create tenant database users with row-level security**
 
-Each tenant needs a dedicated database user that only has access to their white-label data.
+Each tenant needs a dedicated database role whose name encodes the `white_label_id`. RLS uses **username-based filtering** — the policy extracts the `white_label_id` from the connecting role's name via `regexp_match(current_user, '^wl_[a-z_]+_([0-9]+)_ro$')`. Only roles matching the `wl_<state>_<white_label_id>_ro` convention see their tenant's data; non-conforming roles get zero rows.
 
 **Important:** Before running these commands:
 - Replace `white_label_id` values with the correct IDs from your MyFriendBen database
 - Update the database name (`mfb`) and credentials to match your local setup
 
 ```bash
-# Set password as environment variable (keeps it out of shell history)
-export DB_PASSWORD="secure_password"
-
 psql -h localhost -U postgres -d mfb << EOF
--- Create user for North Carolina (white_label_id = 5)
-CREATE USER nc WITH PASSWORD '$DB_PASSWORD';
-ALTER USER nc SET rls.white_label_id = '5';
-GRANT CONNECT ON DATABASE mfb TO nc;
-GRANT USAGE ON SCHEMA analytics TO nc;
-GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO nc;
+-- Create role for North Carolina (white_label_id = 5)
+CREATE ROLE wl_nc_5_ro LOGIN;
+GRANT CONNECT ON DATABASE mfb TO wl_nc_5_ro;
+GRANT USAGE ON SCHEMA analytics TO wl_nc_5_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO wl_nc_5_ro;
 
--- Create user for Colorado (white_label_id = 1)
-CREATE USER co WITH PASSWORD '$DB_PASSWORD';
-ALTER USER co SET rls.white_label_id = '1';
-GRANT CONNECT ON DATABASE mfb TO co;
-GRANT USAGE ON SCHEMA analytics TO co;
-GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO co;
+-- Create role for Colorado (white_label_id = 1)
+CREATE ROLE wl_co_1_ro LOGIN;
+GRANT CONNECT ON DATABASE mfb TO wl_co_1_ro;
+GRANT USAGE ON SCHEMA analytics TO wl_co_1_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO wl_co_1_ro;
 EOF
-
-unset DB_PASSWORD
 ```
 
 **4. Configure Terraform variables**
@@ -87,7 +80,7 @@ terraform init
 
 # Step 2: Create databases, groups, collections, and cards.
 # This also triggers Metabase to sync schemas and create its built-in groups/objects.
-terraform apply -auto-approve
+terraform apply
 
 # Step 3: Import the permissions graph singleton into Terraform state.
 # (Must happen after apply so Metabase's default groups and databases exist.)
@@ -176,10 +169,11 @@ tenants = {
 }
 
 # Add tenant database credentials
+# Convention: wl_<state>_<white_label_id>_ro — RLS policy extracts white_label_id from the username
 tenant_db_credentials = {
-  nc = { username = "nc", password = "secure_password" }
-  co = { username = "co", password = "secure_password" }
-  tx = { username = "tx", password = "secure_password" }  # ← New credentials
+  nc = { username = "wl_nc_5_ro",  password = "secure_password" }
+  co = { username = "wl_co_1_ro",  password = "secure_password" }
+  tx = { username = "wl_tx_40_ro", password = "secure_password" }  # ← New credentials
 }
 ```
 
@@ -216,23 +210,18 @@ locals {
 
 ### 3. Create Database User
 
-Create a new database user with row-level security (see Quick Start step 3 for detailed instructions).
+Create a new database role with row-level security (see Quick Start step 3 for detailed instructions).
 
 **Note:** Check your MyFriendBen database to find the correct `white_label_id` for the new tenant.
 
 ```bash
-export DB_PASSWORD="secure_password"
-
 psql -h localhost -U postgres -d mfb << EOF
--- Create user for Texas (white_label_id = 40)
-CREATE USER tx WITH PASSWORD '$DB_PASSWORD';
-ALTER USER tx SET rls.white_label_id = '40';
-GRANT CONNECT ON DATABASE mfb TO tx;
-GRANT USAGE ON SCHEMA analytics TO tx;
-GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO tx;
+-- Create role for Texas (white_label_id = 40)
+CREATE ROLE wl_tx_40_ro LOGIN;
+GRANT CONNECT ON DATABASE mfb TO wl_tx_40_ro;
+GRANT USAGE ON SCHEMA analytics TO wl_tx_40_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO wl_tx_40_ro;
 EOF
-
-unset DB_PASSWORD
 ```
 
 ### 4. Deploy New Tenant

--- a/dashboards/permissions.tf
+++ b/dashboards/permissions.tf
@@ -54,8 +54,9 @@ resource "metabase_permissions_group" "tenant" {
 # =============================================================================
 
 resource "metabase_collection_graph" "graph" {
-  # Ignore the Administrators group (id = 2) - its permissions cannot be changed.
-  ignored_groups = [2]
+  # Ignore Administrators (id=2) and any manually created groups so they don't
+  # cause graph errors. See local.ignored_group_ids for the full derivation.
+  ignored_groups = local.ignored_group_ids
 
   permissions = concat(
     # --- Global group: read access to the global collection ------------------

--- a/dashboards/permissions.tf
+++ b/dashboards/permissions.tf
@@ -118,11 +118,22 @@ resource "metabase_collection_graph" "graph" {
 #
 # =============================================================================
 
-# Read the current permissions graph so we can discover which database IDs
-# Metabase already knows about (including built-in / sample databases that are
-# not managed by Terraform). This prevents hardcoding IDs that may differ
-# between Metabase versions or environments.
-data "metabase_permissions_graph" "current" {}
+# Fetch all database and group IDs from Metabase to discover unmanaged ones.
+#
+# We use /api/database and /api/permissions/group directly rather than the
+# metabase_permissions_graph data source because that data source crashes when
+# any group has schema-level (object-style) create-queries permissions — a bug
+# in flovouin/terraform-provider-metabase that affects create-queries but not
+# view-data. See: https://github.com/flovouin/terraform-provider-metabase/issues
+data "external" "metabase_ids" {
+  program = ["python3", "${path.module}/scripts/get_metabase_ids.py"]
+
+  query = {
+    metabase_url = var.metabase_url
+    username     = var.metabase_admin_email
+    password     = var.metabase_admin_password
+  }
+}
 
 locals {
   # All managed database IDs in one place for easy reuse across permission rules.
@@ -133,12 +144,11 @@ locals {
   )
 
   # Databases that exist in Metabase but are NOT managed by Terraform
-  # (e.g. Metabase's built-in H2 sample database). Derived dynamically from
-  # the current permissions graph so the list stays correct across environments
-  # and Metabase upgrades — no hardcoded IDs needed.
+  # (e.g. Metabase's built-in H2 sample database). Derived dynamically so the
+  # list stays correct across environments and Metabase upgrades.
   unmanaged_db_ids = setsubtract(
-    toset([for p in data.metabase_permissions_graph.current.permissions : p.database]),
-    toset(local.all_db_ids)
+    toset([for id in jsondecode(data.external.metabase_ids.result.db_ids) : tostring(id)]),
+    toset([for id in local.all_db_ids : tostring(id)])
   )
 
   # Every database ID that must appear in the graph (managed + unmanaged).
@@ -152,29 +162,26 @@ locals {
   )
 
   # Groups that exist in Metabase but are NOT managed by Terraform.
-  # Discovered dynamically from the current permissions graph so that groups
-  # created manually in the Metabase UI are automatically added to
-  # `ignored_groups` below. When a group is ignored, Terraform neither reads
-  # nor updates its permissions — whatever is configured manually in the
-  # Metabase UI stays untouched. Excludes Administrators (id = 2) since it's
-  # always ignored.
+  # Discovered dynamically so that groups created manually in the Metabase UI
+  # are automatically ignored — Terraform neither reads nor updates their
+  # permissions. Excludes Administrators (id = 2) since it's always ignored.
   unmanaged_group_ids = setsubtract(
     setsubtract(
-      toset([for p in data.metabase_permissions_graph.current.permissions : p.group]),
-      toset(local.all_managed_group_ids)
+      toset([for id in jsondecode(data.external.metabase_ids.result.group_ids) : tostring(id)]),
+      toset([for id in local.all_managed_group_ids : tostring(id)])
     ),
-    toset([2])
+    toset(["2"])
   )
+
+  # All groups to ignore across both graph resources: Administrators (id=2) plus
+  # any unmanaged groups. Centralised here so collection_graph and
+  # permissions_graph stay in sync automatically.
+  ignored_group_ids = concat([2], [for id in local.unmanaged_group_ids : tonumber(id)])
 }
 
 resource "metabase_permissions_graph" "graph" {
-  # Ignore Administrators (id = 2) and any groups not managed by Terraform.
-  # When a group is ignored the provider skips it on both read and update,
-  # so its permissions stay whatever is set in the Metabase UI.
-  ignored_groups = concat(
-    [2],
-    [for id in local.unmanaged_group_ids : tonumber(id)]
-  )
+  # Ignore Administrators (id=2) and any unmanaged groups — see local.ignored_group_ids.
+  ignored_groups = local.ignored_group_ids
 
   # advanced_permissions = false uses the free-tier permission model (view_data
   # is always "unrestricted"; access is controlled via create_queries).

--- a/dashboards/scripts/get_metabase_ids.py
+++ b/dashboards/scripts/get_metabase_ids.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Fetch all database IDs and permission group IDs from Metabase.
+
+Workaround for a bug in flovouin/terraform-provider-metabase where the
+metabase_permissions_graph data source crashes when create-queries is
+returned as a schema-level object rather than a flat string. This script
+queries /api/database and /api/permissions/group directly — endpoints that
+don't include permission data and can't trigger the crash.
+
+See: https://github.com/flovouin/terraform-provider-metabase/issues (upstream)
+
+Input (JSON on stdin):
+  {
+    "metabase_url": "http://localhost:3001",
+    "username": "admin@example.com",
+    "password": "secret"
+  }
+
+Output (JSON on stdout – flat string values for Terraform external data source):
+  {"db_ids": "[1, 2, 3]", "group_ids": "[1, 2, 3, 4]"}
+"""
+
+import json
+import sys
+import urllib.error
+import urllib.request
+
+REQUEST_TIMEOUT_SECONDS = 15
+
+
+def _load_json(req, context):
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(
+            f"{context} failed with HTTP {exc.code}: {exc.reason}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"{context} failed: {exc.reason}") from exc
+
+
+def get_session(metabase_url, username, password):
+    req = urllib.request.Request(
+        f"{metabase_url}/api/session",
+        data=json.dumps({"username": username, "password": password}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    return _load_json(req, "Creating Metabase session")["id"]
+
+
+def delete_session(base_url, session_id):
+    req = urllib.request.Request(
+        f"{base_url}/api/session",
+        headers={"X-Metabase-Session": session_id},
+        method="DELETE",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS):
+            pass
+    except (urllib.error.HTTPError, urllib.error.URLError):
+        pass  # best-effort; don't mask the real result
+
+
+_PAGE_SIZE = 50
+
+
+def _get_all_databases(base_url, headers):
+    db_list = []
+    offset = 0
+
+    while True:
+        req = urllib.request.Request(
+            f"{base_url}/api/database?limit={_PAGE_SIZE}&offset={offset}",
+            headers=headers,
+        )
+
+        data = _load_json(req, "Listing Metabase databases")
+
+        if isinstance(data, dict):
+            if "data" not in data:
+                raise SystemExit(f"Unexpected Metabase database response: {data}")
+
+            page = data["data"]
+            if not isinstance(page, list):
+                raise SystemExit(f"Expected 'data' to be a list, got: {type(page)}")
+
+            total = data.get("total")
+            db_list.extend(page)
+
+            if not page or (total is not None and len(db_list) >= total):
+                break
+
+            offset += _PAGE_SIZE
+
+        elif isinstance(data, list):
+            db_list.extend(data)
+            break
+
+        else:
+            raise SystemExit(
+                f"Unexpected Metabase database response type: {type(data)}"
+            )
+
+    return db_list
+
+
+def _get_all_groups(base_url, headers):
+    # /api/permissions/group returns at most 50 items — paginate to get all.
+    group_ids = []
+    offset = 0
+    while True:
+        req = urllib.request.Request(
+            f"{base_url}/api/permissions/group?limit={_PAGE_SIZE}&offset={offset}",
+            headers=headers,
+        )
+        page = _load_json(req, "Listing Metabase permission groups")
+        if not isinstance(page, list):
+            raise SystemExit(f"Unexpected permissions/group response: {page}")
+        group_ids.extend(g["id"] for g in page if isinstance(g, dict))
+        if len(page) < _PAGE_SIZE:
+            break
+        offset += _PAGE_SIZE
+    return group_ids
+
+
+def main():
+    query = json.load(sys.stdin)
+    base_url = query["metabase_url"].rstrip("/")
+    session_id = get_session(base_url, query["username"], query["password"])
+    try:
+        headers = {"X-Metabase-Session": session_id}
+
+        db_ids = [
+            db["id"] for db in _get_all_databases(base_url, headers) if isinstance(db, dict)
+        ]
+
+        group_ids = _get_all_groups(base_url, headers)
+
+        print(
+            json.dumps(
+                {
+                    "db_ids": json.dumps(db_ids),
+                    "group_ids": json.dumps(group_ids),
+                }
+            )
+        )
+    finally:
+        delete_session(base_url, session_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Context & Motivation

The `flovouin/terraform-provider-metabase` provider crashes during `terraform plan` and `terraform apply` when any Metabase group has schema-level (per-schema) create-queries permissions instead of a flat string value. This is a bug in the provider's JSON unmarshaling, it cannot handle an object-style value for that field.

This is mainly encountered during initial onboarding/setup. Without this fix, `terraform apply` failed immediately before creating any resources. 

`json: cannot unmarshal object into Go struct field PermissionsGraphDatabasePermissions.groups.create-queries`

<img width="1068" height="195" alt="Screenshot 2026-04-24 at 10 45 56 AM" src="https://github.com/user-attachments/assets/cffa8235-4752-489b-b01a-5a38b4354b31" />

---
Also:
- Updates docs to reflect latest RLS policy during setup.

## Changes Made

- Replaced data `metabase_permissions_graph` `current` (the source of the crash) with data `external` `metabase_ids` backed by a new Python script
- Added `get_metabase_ids.py`: queries /api/database and /api/permissions/group directly (endpoints that return no permission data and cannot trigger the crash) with full pagination support
- Centralized ignored_group_ids into a single local shared across both graph resources (collection_graph and permissions_graph), removing a DRY violation
- Updated role naming convention in docs from plain names (nc, co) to wl_<state>_<white_label_id>_ro to reflect username-based RLS filtering
- Added troubleshooting sections to README for the 409 stale state error and the unmarshal crash, including known limitations of this fix

## Testing

- Local Metabase tested via docker-compose: yes
- Other manual testing steps:
  -  Verified Python script runs independently:
      `echo '{"metabase_url":"http://localhost:3001","username":"...","password":"..."}' | python3 dashboards/scripts/get_metabase_ids.py`
    - Confirmed `terraform apply` succeeds on initial setup (no existing state) with the
      data source crash fix in place
    - Confirmed `terraform import` still fails when a group with schema-level permissions
      exists — UI fix required first (documented in README troubleshooting)
    - Confirmed `terraform plan` correctly detects and ignores manually created groups
      via `ignored_groups`

## Deployment

- Production Terraform apply needed: no
- Metabase container rebuild/redeploy needed: no
- dbt production run needed (outside nightly cron): no

## Notes for Reviewers

  - **Known limitation**: This fix prevents the crash during initial terraform apply (the primary onboarding use case). However, terraform import `metabase_permissions_graph.graph 1` still hits the same provider bug directly. If a group with schema-level permissions exists, you must fix it in the Metabase UI (Admin → Permissions → change to a flat top-level value) before running any import. This is documented in the README troubleshooting section. These also seem to mainly be edge cases.
  - **Future consideration**: A proper fix requires patching the upstream provider to handle object-style create-queries values gracefully.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated database access configuration guidance with new role-naming conventions.
  * Expanded troubleshooting section with additional workflow solutions for permissions and state issues.
  * Added operational safety warnings for production environments.

* **Infrastructure**
  * Improved automated discovery of database and permission group identifiers during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->