### PR TITLE
MFB-960: Add per-tenant Metabase editor permission groups

### DIFF
--- a/dashboards/outputs.tf
+++ b/dashboards/outputs.tf
@@ -19,9 +19,17 @@ output "global_group_id" {
 }
 
 output "tenant_group_ids" {
-  description = "Metabase group IDs for each per-tenant group (keyed by tenant key)"
+  description = "Metabase group IDs for each per-tenant viewer group (keyed by tenant key)"
   value = {
     for k, g in metabase_permissions_group.tenant :
+    k => g.id
+  }
+}
+
+output "tenant_editor_group_ids" {
+  description = "Metabase group IDs for each per-tenant editor group (keyed by tenant key)"
+  value = {
+    for k, g in metabase_permissions_group.tenant_editor :
     k => g.id
   }
 }

--- a/dashboards/permissions.tf
+++ b/dashboards/permissions.tf
@@ -117,7 +117,7 @@ resource "metabase_collection_graph" "graph" {
 #
 # Rules:
 #   - All Users (1)       → no query access to any database (baseline deny for everyone)
-#   - Global group        → full query access (query-builder-and-native) to all databases
+#   - Global group        → full query access (query-builder-and-native) to all managed databases; no access to unmanaged databases
 #   - Tenant viewer group → query-builder access to their own tenant DB only; no access elsewhere
 #   - Tenant editor group → same as viewer group (write collection access ≠ elevated DB access)
 #

--- a/dashboards/permissions.tf
+++ b/dashboards/permissions.tf
@@ -35,6 +35,17 @@ resource "metabase_permissions_group" "tenant" {
   name = "${each.value.display_name} Viewers"
 }
 
+# --- Per-tenant editor groups ------------------------------------------------
+#
+# Parallel to viewer groups but with write collection access. Data permissions
+# remain identical to viewer groups.
+
+resource "metabase_permissions_group" "tenant_editor" {
+  for_each = var.tenants
+
+  name = "${each.value.display_name} Editors"
+}
+
 # =============================================================================
 # Collection Permissions Graph
 # =============================================================================
@@ -42,9 +53,10 @@ resource "metabase_permissions_group" "tenant" {
 # Controls which groups can see which collections (dashboards).
 #
 # Rules:
-#   - Global group  → read on Global collection AND all tenant collections
-#   - Tenant group  → read-only on their own tenant collection only
-#   - All Users (1) → no access to any collection (default deny)
+#   - Global group        → read on Global collection AND all tenant collections
+#   - Tenant viewer group → read-only on their own tenant collection only
+#   - Tenant editor group → write on their own tenant collection only
+#   - All Users (1)       → no access to any collection (default deny)
 #
 # The collection_graph is a singleton in Metabase. It must be imported on first
 # use rather than created from scratch:
@@ -84,6 +96,15 @@ resource "metabase_collection_graph" "graph" {
         collection = local.tenant_collection_map[key].id
         permission = "read"
       } if contains(keys(local.tenant_collection_map), key)
+    ],
+
+    # --- Per-tenant editor group: write access to their own collection --------
+    [
+      for key, tenant in var.tenants : {
+        group      = metabase_permissions_group.tenant_editor[key].id
+        collection = local.tenant_collection_map[key].id
+        permission = "write"
+      } if contains(keys(local.tenant_collection_map), key)
     ]
   )
 }
@@ -95,10 +116,10 @@ resource "metabase_collection_graph" "graph" {
 # Controls which groups can query which databases in the Metabase query builder.
 #
 # Rules:
-#   - All Users (1)  → no query access to any database (baseline deny for everyone)
-#   - Global group   → full query access (query-builder-and-native) to all databases
-#   - Tenant group   → query-builder access to their own tenant DB only;
-#                      no access to all other DBs
+#   - All Users (1)       → no query access to any database (baseline deny for everyone)
+#   - Global group        → full query access (query-builder-and-native) to all databases
+#   - Tenant viewer group → query-builder access to their own tenant DB only; no access elsewhere
+#   - Tenant editor group → same as viewer group (write collection access ≠ elevated DB access)
 #
 # This closes the gap that collection permissions alone cannot address: without
 # this, a user scoped to the NC group can still browse the CO database directly
@@ -158,7 +179,8 @@ locals {
   all_managed_group_ids = concat(
     [1], # All Users group
     [metabase_permissions_group.global.id],
-    [for k, g in metabase_permissions_group.tenant : g.id]
+    [for k, g in metabase_permissions_group.tenant : g.id],
+    [for k, g in metabase_permissions_group.tenant_editor : g.id]
   )
 
   # Groups that exist in Metabase but are NOT managed by Terraform.
@@ -256,6 +278,47 @@ resource "metabase_permissions_graph" "graph" {
         [
           for db_id in local.unmanaged_db_ids : {
             group          = metabase_permissions_group.tenant[tenant_key].id
+            database       = tonumber(db_id)
+            view_data      = "unrestricted"
+            create_queries = "no"
+            download       = { schemas = "full" }
+            data_model     = null
+          }
+        ]
+      )
+    ]),
+
+    # --- Per-tenant editor groups: query-builder on own DB only ---------------
+    # Identical to viewer data perms — write collection access ≠ elevated DB access.
+    flatten([
+      for tenant_key, tenant in var.tenants : concat(
+        # Own database: allow query builder
+        [
+          {
+            group          = metabase_permissions_group.tenant_editor[tenant_key].id
+            database       = tonumber(metabase_database.tenant_postgres[tenant_key].id)
+            view_data      = "unrestricted"
+            create_queries = "query-builder"
+            download       = { schemas = "full" }
+            data_model     = null
+          }
+        ],
+        # All other managed databases: no access
+        [
+          for db_id in local.all_db_ids : {
+            group          = metabase_permissions_group.tenant_editor[tenant_key].id
+            database       = tonumber(db_id)
+            view_data      = "unrestricted"
+            create_queries = "no"
+            download       = { schemas = "full" }
+            data_model     = null
+          }
+          if tonumber(db_id) != tonumber(metabase_database.tenant_postgres[tenant_key].id)
+        ],
+        # Unmanaged databases: no access
+        [
+          for db_id in local.unmanaged_db_ids : {
+            group          = metabase_permissions_group.tenant_editor[tenant_key].id
             database       = tonumber(db_id)
             view_data      = "unrestricted"
             create_queries = "no"


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes #[MFB-960](https://linear.app/myfriendben/issue/MFB-960/data-add-per-tenant-metabase-editor-permission-groups)

We have read-only viewer groups per tenant (e.g. "North Carolina Viewers") but
no way to give users write access scoped to their tenant. This adds a parallel
set of editor groups so users who need to create and save custom models and
questions can do so inside their tenant collection, without touching the
existing viewer groups or gaining cross-tenant access.

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->
<!-- Examples: dbt models added/modified, Terraform resources updated, Metabase container change, scripts added -->

- All changes are in `dashboards/permissions.tf`:

- Added `metabase_permissions_group.tenant_editor` resource using `for_each = var.tenants` - creates one `{Display Name} Editors` group per  tenant, mirroring the existing viewer resource
- Registered editor groups in `local.all_managed_group_ids` so they are included in the permission graphs (without this, Terraform would silently treat them as unmanaged and never write their permissions)
- Added `write` collection permission block in `metabase_collection_graph.graph` - editors can save into their own tenant collection only
- Added `flatten([...])` data permissions block in `metabase_permissions_graph.graph` - query-builder access to own tenant DB only, identical to viewer groups (per ticket spec)

## Testing

<!-- Steps needed to test this PR locally -->

- dbt models to run: n/a
- Terraform plan reviewed: <!-- paste or link to plan output if applicable -->
- Local Metabase tested via docker-compose: yes
- Other manual testing steps:
- 17 groups in Admin → People → Groups (10 existing + 7 new editor groups) 
<img width="1996" height="1389" alt="Screen Shot 2026-05-11 at 2 00 02 PM" src="https://github.com/user-attachments/assets/7c3aa5a5-9664-42e1-9129-64163245fdd0" />

- Permissions → Collections → North Carolina: North Carolina Editors → Curate,
  all other tenant editors → No access, viewer groups unchanged 
<img width="1192" height="1076" alt="Screen Shot 2026-05-11 at 2 00 28 PM" src="https://github.com/user-attachments/assets/5ba78be4-40c9-4312-8800-1d5b103c6d93" />

- Permissions → Data → North Carolina Editors: Query builder only on MFB
  PostgreSQL North Carolina, No on every other DB 
<img width="932" height="857" alt="Screen Shot 2026-05-11 at 2 00 43 PM" src="https://github.com/user-attachments/assets/6972e941-34dd-4e9e-b884-57fc6bb4510b" />

  - Created test user in "North Carolina Editors" only — confirmed: NC collection visible and writable (can save questions), all other tenant collections blocked, MFB PostgreSQL North Carolina query-builder only, no other DBs
  - Created test user in "North Carolina Viewers" only — confirmed: viewer  behavior unchanged, NC collection readable but not writable

## Deployment

<!--
Merging to main automatically applies Terraform changes to Staging.
Production Terraform and Metabase container deployments require manual steps — note them here.
-->

- [x] Production Terraform apply needed: yes 
- [ ] Metabase container rebuild/redeploy needed: no
- [ ] dbt production run needed (outside nightly cron): no
- [x] Other post-deployment steps:
- After apply on each environment, the new editor groups are **empty**.
  Add users via Metabase Admin → People → [user] → Groups.

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- The `local.all_managed_group_ids` addition is the non-obvious
part: without it, Terraform classifies the new groups as "unmanaged" and
skips writing their permission rules into the graphs - the groups would exist
in Metabase but have no permissions at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced per-tenant Editor role that can write to their tenant's collections while preserving tenant isolation.
  * Editor permissions extended to allow query-builder access for each tenant across managed and unmanaged databases.

* **Documentation**
  * Admin outputs/exports clarified to include per-tenant Editor group identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/data-queries/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->