### PR TITLE
One-off: Terraform destroy workflow for staging (MFB-962)

### DIFF
--- a/.github/workflows/terraform-destroy-staging.yml
+++ b/.github/workflows/terraform-destroy-staging.yml
@@ -11,9 +11,9 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: 'Type DESTROY-STAGING to apply. Leave blank for plan-only.'
+        description: "Type DESTROY-STAGING to apply. Leave blank for plan-only."
         required: false
-        default: ''
+        default: ""
 
 permissions:
   contents: read

--- a/.github/workflows/terraform-destroy-staging.yml
+++ b/.github/workflows/terraform-destroy-staging.yml
@@ -123,6 +123,7 @@ jobs:
           echo "safe=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload destroy plan as artifact
+        if: always() && hashFiles('dashboards/destroy-preview.txt') != ''
         uses: actions/upload-artifact@v4
         with:
           name: destroy-plan

--- a/.github/workflows/terraform-destroy-staging.yml
+++ b/.github/workflows/terraform-destroy-staging.yml
@@ -15,6 +15,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   destroy:
     runs-on: ubuntu-latest
@@ -36,11 +39,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Confirm workspace identity
+        run: |
+          if [[ "$TF_WORKSPACE" != "mfb-dashboards-staging" ]]; then
+            echo "::error::TF_WORKSPACE is $TF_WORKSPACE, expected mfb-dashboards-staging"
+            exit 1
+          fi
+
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.9.x"
           terraform_wrapper: false
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Authenticate to Google Cloud
+        if: vars.BIGQUERY_ENABLED == 'true'
+        run: |
+          echo '${{ secrets.BIGQUERY_SA_KEY }}' > ${{ github.workspace }}/gcp-key.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=${{ github.workspace }}/gcp-key.json" >> "$GITHUB_ENV"
 
       - name: Build Terraform credential JSON variables
         run: |
@@ -93,6 +109,7 @@ jobs:
         run: terraform plan -destroy -out=destroy.tfplan
 
       - name: Safety check — confirm no production references in destroy plan
+        id: safety
         run: |
           terraform show destroy.tfplan > destroy-preview.txt
           echo "=== Destroy plan summary ==="
@@ -103,6 +120,7 @@ jobs:
             exit 1
           fi
           echo "No production references found. Safe to apply."
+          echo "safe=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload destroy plan as artifact
         uses: actions/upload-artifact@v4
@@ -112,7 +130,7 @@ jobs:
           retention-days: 30
 
       - name: Terraform Apply (destroy)
-        if: ${{ inputs.confirm == 'DESTROY-STAGING' }}
+        if: ${{ inputs.confirm == 'DESTROY-STAGING' && steps.safety.outputs.safe == 'true' }}
         run: terraform apply destroy.tfplan
 
       - name: Plan-only notice

--- a/.github/workflows/terraform-destroy-staging.yml
+++ b/.github/workflows/terraform-destroy-staging.yml
@@ -39,13 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Confirm workspace identity
-        run: |
-          if [[ "$TF_WORKSPACE" != "mfb-dashboards-staging" ]]; then
-            echo "::error::TF_WORKSPACE is $TF_WORKSPACE, expected mfb-dashboards-staging"
-            exit 1
-          fi
-
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.9.x"
@@ -110,14 +103,22 @@ jobs:
 
       - name: Safety check — confirm no production references in destroy plan
         id: safety
+        env:
+          CONFIRM: ${{ inputs.confirm }}
         run: |
           terraform show destroy.tfplan > destroy-preview.txt
           echo "=== Destroy plan summary ==="
           grep -c "will be destroyed" destroy-preview.txt || true
           echo "=== Scanning for production references ==="
           if grep -iE "mfb-metabase-production|baf31df893fc|mfb-dashboards-production" destroy-preview.txt; then
-            echo "::error::Destroy plan contains references to production resources. Aborting."
-            exit 1
+            if [[ "$CONFIRM" == "DESTROY-STAGING" ]]; then
+              echo "::error::Destroy plan contains references to production resources. Aborting apply."
+              exit 1
+            else
+              echo "::warning::Destroy plan contains references to production resources. Review the artifact carefully — an apply would be blocked."
+              echo "safe=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
           echo "No production references found. Safe to apply."
           echo "safe=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/terraform-destroy-staging.yml
+++ b/.github/workflows/terraform-destroy-staging.yml
@@ -1,0 +1,121 @@
+name: Terraform Destroy Staging (one-off)
+
+# One-off workflow to tear down the mfb-dashboards-staging TFC workspace.
+# Per PR #77 (MFB-962). Delete this workflow file after the destroy completes.
+#
+# Two-stage flow:
+#   1. Run with `confirm` left blank  -> plan-only, prints what would be destroyed.
+#   2. Run with `confirm = DESTROY-STAGING` -> applies the destroy.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type DESTROY-STAGING to apply. Leave blank for plan-only.'
+        required: false
+        default: ''
+
+jobs:
+  destroy:
+    runs-on: ubuntu-latest
+    environment: staging
+    defaults:
+      run:
+        working-directory: dashboards
+    env:
+      TF_WORKSPACE: mfb-dashboards-staging
+      TF_VAR_metabase_url: ${{ vars.METABASE_URL }}
+      TF_VAR_metabase_admin_email: ${{ vars.METABASE_ADMIN_EMAIL }}
+      TF_VAR_metabase_admin_password: ${{ secrets.METABASE_ADMIN_PASSWORD }}
+      TF_VAR_database_host: ${{ secrets.DATABASE_HOST }}
+      TF_VAR_database_name: ${{ vars.DATABASE_NAME }}
+      TF_VAR_database_ssl: "true"
+      TF_VAR_bigquery_enabled: ${{ vars.BIGQUERY_ENABLED || 'false' }}
+      TF_VAR_bigquery_service_account_key_content: ${{ secrets.BIGQUERY_SA_KEY }}
+      TF_VAR_gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.x"
+          terraform_wrapper: false
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Build Terraform credential JSON variables
+        run: |
+          global_creds=$(jq -cn \
+            --arg user "$GLOBAL_DB_USER" \
+            --arg pass "$GLOBAL_DB_PASS" \
+            '{username: $user, password: $pass}')
+          tenant_creds=$(jq -cn \
+            --arg nc_user "$NC_DB_USER" --arg nc_pass "$NC_DB_PASS" \
+            --arg co_user "$CO_DB_USER" --arg co_pass "$CO_DB_PASS" \
+            --arg tx_user "$TX_DB_USER" --arg tx_pass "$TX_DB_PASS" \
+            --arg il_user "$IL_DB_USER" --arg il_pass "$IL_DB_PASS" \
+            --arg ma_user "$MA_DB_USER" --arg ma_pass "$MA_DB_PASS" \
+            --arg cesn_user "$CESN_DB_USER" --arg cesn_pass "$CESN_DB_PASS" \
+            --arg cotc_user "$CO_TAX_CALCULATOR_DB_USER" --arg cotc_pass "$CO_TAX_CALCULATOR_DB_PASS" \
+            '
+              {}
+              + (if $nc_user != "" and $nc_pass != "" then {nc: {username: $nc_user, password: $nc_pass}} else {} end)
+              + (if $co_user != "" and $co_pass != "" then {co: {username: $co_user, password: $co_pass}} else {} end)
+              + (if $tx_user != "" and $tx_pass != "" then {tx: {username: $tx_user, password: $tx_pass}} else {} end)
+              + (if $il_user != "" and $il_pass != "" then {il: {username: $il_user, password: $il_pass}} else {} end)
+              + (if $ma_user != "" and $ma_pass != "" then {ma: {username: $ma_user, password: $ma_pass}} else {} end)
+              + (if $cesn_user != "" and $cesn_pass != "" then {cesn: {username: $cesn_user, password: $cesn_pass}} else {} end)
+              + (if $cotc_user != "" and $cotc_pass != "" then {co_tax_calculator: {username: $cotc_user, password: $cotc_pass}} else {} end)
+            ')
+          echo "TF_VAR_global_db_credentials=$global_creds" >> "$GITHUB_ENV"
+          echo "TF_VAR_tenant_db_credentials=$tenant_creds" >> "$GITHUB_ENV"
+        env:
+          GLOBAL_DB_USER: ${{ secrets.GLOBAL_DB_USER }}
+          GLOBAL_DB_PASS: ${{ secrets.GLOBAL_DB_PASS }}
+          NC_DB_USER: ${{ secrets.NC_DB_USER }}
+          NC_DB_PASS: ${{ secrets.NC_DB_PASS }}
+          CO_DB_USER: ${{ secrets.CO_DB_USER }}
+          CO_DB_PASS: ${{ secrets.CO_DB_PASS }}
+          TX_DB_USER: ${{ secrets.TX_DB_USER }}
+          TX_DB_PASS: ${{ secrets.TX_DB_PASS }}
+          IL_DB_USER: ${{ secrets.IL_DB_USER }}
+          IL_DB_PASS: ${{ secrets.IL_DB_PASS }}
+          MA_DB_USER: ${{ secrets.MA_DB_USER }}
+          MA_DB_PASS: ${{ secrets.MA_DB_PASS }}
+          CESN_DB_USER: ${{ secrets.CESN_DB_USER }}
+          CESN_DB_PASS: ${{ secrets.CESN_DB_PASS }}
+          CO_TAX_CALCULATOR_DB_USER: ${{ secrets.CO_TAX_CALCULATOR_DB_USER }}
+          CO_TAX_CALCULATOR_DB_PASS: ${{ secrets.CO_TAX_CALCULATOR_DB_PASS }}
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Plan (destroy)
+        run: terraform plan -destroy -out=destroy.tfplan
+
+      - name: Safety check — confirm no production references in destroy plan
+        run: |
+          terraform show destroy.tfplan > destroy-preview.txt
+          echo "=== Destroy plan summary ==="
+          grep -c "will be destroyed" destroy-preview.txt || true
+          echo "=== Scanning for production references ==="
+          if grep -iE "mfb-metabase-production|baf31df893fc|mfb-dashboards-production" destroy-preview.txt; then
+            echo "::error::Destroy plan contains references to production resources. Aborting."
+            exit 1
+          fi
+          echo "No production references found. Safe to apply."
+
+      - name: Upload destroy plan as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: destroy-plan
+          path: dashboards/destroy-preview.txt
+          retention-days: 30
+
+      - name: Terraform Apply (destroy)
+        if: ${{ inputs.confirm == 'DESTROY-STAGING' }}
+        run: terraform apply destroy.tfplan
+
+      - name: Plan-only notice
+        if: ${{ inputs.confirm != 'DESTROY-STAGING' }}
+        run: |
+          echo "::notice::Plan-only run. To actually destroy, re-run this workflow with confirm=DESTROY-STAGING"

--- a/.github/workflows/terraform-destroy-staging.yml
+++ b/.github/workflows/terraform-destroy-staging.yml
@@ -39,6 +39,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Assert workspace is staging
+        run: |
+          if [[ "$TF_WORKSPACE" != *staging* ]]; then
+            echo "::error::TF_WORKSPACE does not look like a staging workspace: $TF_WORKSPACE"
+            exit 1
+          fi
+
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.9.x"


### PR DESCRIPTION
## Summary

One-off workflow to tear down the `mfb-dashboards-staging` Terraform Cloud workspace per [PR #77](https://github.com/MyFriendBen/data-queries/pull/77) Step 3 (MFB-962).

## Why a workflow vs running locally

The `mfb-dashboards-staging` workspace is in TFC Local execution mode — TFC stores state but plan/apply runs on the executor. PR #77 removed the staging-targeting workflows, so there's no automated destroy path. The staging GitHub Actions environment and its secrets still exist, which lets a one-off workflow run a destroy without anyone needing to handle credentials manually.

## Safety features

- **Two-stage:** default run is plan-only. Apply only runs when `confirm=DESTROY-STAGING` is typed into the input field.
- **Plan artifact:** the destroy plan is uploaded as a downloadable artifact for review.
- **Automated safety check:** the job fails before apply if the destroy plan mentions any production resource (`mfb-metabase-production`, `baf31df893fc`, `mfb-dashboards-production`).
- **Environment-scoped:** uses the existing `staging` GitHub environment, so destroy can only see staging secrets/vars.

## Plan

1. Merge this PR (workflow becomes runnable on `main`)
2. Run workflow with `confirm` blank — plan-only, review the artifact
3. Run workflow with `confirm=DESTROY-STAGING` — applies the destroy
4. Open a follow-up PR to delete this workflow file

## Test plan

- [ ] Plan-only run completes and produces a clean destroy preview (~509 resources, no prod references)
- [ ] Apply run succeeds and the TFC `mfb-dashboards-staging` workspace shows 0 resources
- [ ] No production runs are triggered during either run