### PR TITLE
Fix: program foreign names in Benefits & Immediate Needs

### DIFF
--- a/dbt/models/postgres/marts/mart_qualified_benefits.sql
+++ b/dbt/models/postgres/marts/mart_qualified_benefits.sql
@@ -6,21 +6,45 @@
   )
 }}
 
+WITH program_names AS (
+    SELECT
+        pp.name_abbreviated,
+        MAX(tt.text) AS benefit
+    FROM {{ source('django_apps', 'programs_program') }} AS pp
+    INNER JOIN {{ source('django_apps', 'translations_translation_translation') }} AS tt
+        ON
+            pp.name_id = tt.master_id
+            AND tt.language_code = 'en-us'
+    GROUP BY pp.name_abbreviated
+),
+
+benefit_counts AS (
+    SELECT
+        pe.name_abbreviated,
+        COUNT(DISTINCT msd.id) AS count,
+        msd.white_label_id,
+        msd.partner,
+        msd.county
+    FROM {{ ref('mart_screener_data') }} AS msd
+    INNER JOIN {{ ref('stg_program_eligibility') }} AS pe
+        ON
+            msd.latest_snapshot_id = pe.eligibility_snapshot_id
+            AND pe.annual_value > 0
+            AND msd.white_label_id = pe.white_label_id
+    GROUP BY
+        pe.name_abbreviated,
+        msd.white_label_id,
+        msd.partner,
+        msd.county
+)
+
 SELECT
-    MAX(pe.name) AS benefit,
-    pe.name_abbreviated,
-    COUNT(DISTINCT msd.id) AS count,
-    msd.white_label_id,
-    msd.partner,
-    msd.county
-FROM {{ ref('mart_screener_data') }} AS msd
-INNER JOIN {{ ref('stg_program_eligibility') }} AS pe
-    ON
-        msd.latest_snapshot_id = pe.eligibility_snapshot_id
-        AND pe.annual_value > 0
-        AND msd.white_label_id = pe.white_label_id
-GROUP BY
-    pe.name_abbreviated,
-    msd.white_label_id,
-    msd.partner,
-    msd.county
+    COALESCE(pn.benefit, bc.name_abbreviated) AS benefit,
+    bc.name_abbreviated,
+    bc.count,
+    bc.white_label_id,
+    bc.partner,
+    bc.county
+FROM benefit_counts AS bc
+LEFT JOIN program_names AS pn
+    ON bc.name_abbreviated = pn.name_abbreviated

--- a/dbt/models/postgres/marts/mart_qualified_benefits.sql
+++ b/dbt/models/postgres/marts/mart_qualified_benefits.sql
@@ -6,45 +6,29 @@
   )
 }}
 
-WITH program_names AS (
-    SELECT
-        pp.name_abbreviated,
-        MAX(tt.text) AS benefit
-    FROM {{ source('django_apps', 'programs_program') }} AS pp
-    INNER JOIN {{ source('django_apps', 'translations_translation_translation') }} AS tt
-        ON
-            pp.name_id = tt.master_id
-            AND tt.language_code = 'en-us'
-    GROUP BY pp.name_abbreviated
-),
-
-benefit_counts AS (
-    SELECT
-        pe.name_abbreviated,
-        COUNT(DISTINCT msd.id) AS count,
-        msd.white_label_id,
-        msd.partner,
-        msd.county
-    FROM {{ ref('mart_screener_data') }} AS msd
-    INNER JOIN {{ ref('stg_program_eligibility') }} AS pe
-        ON
-            msd.latest_snapshot_id = pe.eligibility_snapshot_id
-            AND pe.annual_value > 0
-            AND msd.white_label_id = pe.white_label_id
-    GROUP BY
-        pe.name_abbreviated,
-        msd.white_label_id,
-        msd.partner,
-        msd.county
-)
-
 SELECT
-    COALESCE(pn.benefit, bc.name_abbreviated) AS benefit,
-    bc.name_abbreviated,
-    bc.count,
-    bc.white_label_id,
-    bc.partner,
-    bc.county
-FROM benefit_counts AS bc
-LEFT JOIN program_names AS pn
-    ON bc.name_abbreviated = pn.name_abbreviated
+    COALESCE(MAX(pn.text), pe.name_abbreviated) AS benefit,
+    pe.name_abbreviated,
+    COUNT(DISTINCT msd.id) AS count,
+    msd.white_label_id,
+    msd.partner,
+    msd.county
+FROM {{ ref('mart_screener_data') }} AS msd
+INNER JOIN {{ ref('stg_program_eligibility') }} AS pe
+    ON
+        msd.latest_snapshot_id = pe.eligibility_snapshot_id
+        AND pe.annual_value > 0
+        AND msd.white_label_id = pe.white_label_id
+LEFT JOIN {{ source('django_apps', 'programs_program') }} AS pp
+    ON
+        pe.name_abbreviated = pp.name_abbreviated
+        AND msd.white_label_id = pp.white_label_id
+LEFT JOIN {{ source('django_apps', 'translations_translation_translation') }} AS pn
+    ON
+        pp.name_id = pn.master_id
+        AND pn.language_code = 'en-us'
+GROUP BY
+    pe.name_abbreviated,
+    msd.white_label_id,
+    msd.partner,
+    msd.county

--- a/dbt/models/postgres/marts/mart_qualified_benefits.yml
+++ b/dbt/models/postgres/marts/mart_qualified_benefits.yml
@@ -15,11 +15,16 @@ models:
           - not_null
 
       - name: benefit
-        description: "Benefit category name"
+        description: "Canonical display name for the benefit program (global MAX across all snapshots, language-independent)"
+        tests:
+          - not_null
+
+      - name: name_abbreviated
+        description: "Language-agnostic program identifier (e.g. 'snap', 'wic'). Use this for grouping instead of benefit to avoid translation duplicates."
         tests:
           - not_null
 
       - name: count
-        description: "Value indicating if a user qualified for the corresponding benefit (1 for true, 0 for false in the source mart, here summed up)"
+        description: "Number of distinct screeners that qualified for this benefit in the given partner/county group"
         tests:
           - not_null

--- a/dbt/models/postgres/marts/mart_qualified_benefits.yml
+++ b/dbt/models/postgres/marts/mart_qualified_benefits.yml
@@ -15,7 +15,7 @@ models:
           - not_null
 
       - name: benefit
-        description: "Canonical display name for the benefit program (global MAX across all snapshots, language-independent)"
+        description: "English (en-us) display name for the benefit program, scoped to the white label. Falls back to name_abbreviated if no English translation exists."
         tests:
           - not_null
 

--- a/dbt/models/postgres/sources.yml
+++ b/dbt/models/postgres/sources.yml
@@ -102,6 +102,8 @@ sources:
             description: "Primary key"
           - name: name_abbreviated
             description: "Abbreviated program name (slug)"
+          - name: name_id
+            description: "Foreign key to translations_translation for the program display name"
           - name: value_type_id
             description: "Foreign key to translations_translation for the value type"
           - name: white_label_id

--- a/dbt/models/postgres/staging/stg_program_eligibility.sql
+++ b/dbt/models/postgres/staging/stg_program_eligibility.sql
@@ -1,12 +1,11 @@
 {{ config(
     materialized='view',
-    description='Program eligibility aggregated by snapshot — one row per eligibility_snapshot_id × name_abbreviated. white_label_id is sourced from screener_screen via the eligibility snapshot chain. No join to programs_program: the snapshot rows are already correctly scoped per-screen at eligibility run time, so cross-WL contamination is not possible, and joining to programs_program would silently drop historical rows whenever a program is renamed, deleted, or reassigned.'
+    description='Program eligibility aggregated by snapshot — one row per eligibility_snapshot_id × name_abbreviated × value_type. pe.name (translated display name) is intentionally excluded: it varies by language and would fan-out rows per translation. white_label_id is sourced from screener_screen via the eligibility snapshot chain. No join to programs_program: the snapshot rows are already correctly scoped per-screen at eligibility run time, so cross-WL contamination is not possible, and joining to programs_program would silently drop historical rows whenever a program is renamed, deleted, or reassigned.'
 ) }}
 
 SELECT
     pe.eligibility_snapshot_id,
     pe.name_abbreviated,
-    pe.name,
     pe.value_type,
     scr.white_label_id,
     sum(pe.estimated_value) AS annual_value
@@ -16,4 +15,4 @@ INNER JOIN {{ source('django_apps', 'screener_eligibilitysnapshot') }} AS es
 INNER JOIN {{ source('django_apps', 'screener_screen') }} AS scr
     ON es.screen_id = scr.id
 WHERE pe.eligible = TRUE
-GROUP BY pe.eligibility_snapshot_id, pe.name_abbreviated, pe.name, pe.value_type, scr.white_label_id
+GROUP BY pe.eligibility_snapshot_id, pe.name_abbreviated, pe.value_type, scr.white_label_id


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes [#950](https://linear.app/myfriendben/issue/MFB-950/replace-hardcoded-program-list-in-dbt-with-dynamic-aggregation-from)
- Related PR: [#80](https://github.com/MyFriendBen/data-queries/pull/80)

## Changes Made

- programs_program → translations_translation_translation via pp.name_id — this is a direct FK join, much more reliable than the label-pattern string matching approach
- language_code = 'en-us' — guarantees English names only
- MAX(tt.text) in program_names is now safe — since it's already filtered to en-us, all rows for the same name_abbreviated should have the same text (at most minor duplicates), so MAX is deterministic
- LEFT JOIN program_names in the final SELECT — programs without a translation entry still appear, falling back to COALESCE(..., bc.name_abbreviated)


## Testing

<!-- Steps needed to test this PR locally -->

- dbt models to run: `dbt run 
- Terraform plan reviewed: no
- Local Metabase tested via docker-compose: yes 

## Deployment

- [ ] Metabase container rebuild/redeploy needed: no
- [ ] dbt production run needed (outside nightly cron): yes 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a language-agnostic program identifier to improve grouping across languages and white-labels.
  * Added a program display-name reference to support translated text.

* **Improvements**
  * Benefit display now prefers translated canonical text with a fallback to the abbreviated name.
  * Qualified screener count clarified to represent distinct qualified screeners per partner/county grouping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/data-queries/pull/91)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->