### PR TITLE
MFB-998: Fix urgent needs / benefits tables when county is NULL

### DIFF
--- a/dashboards/sql/current_benefits.sql
+++ b/dashboards/sql/current_benefits.sql
@@ -1,12 +1,24 @@
-WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]),
-filter_keys AS (SELECT DISTINCT partner, county FROM analytics.mart_screener_data WHERE 1=1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]])
+WITH totals AS (
+    SELECT count(*) AS total_count
+    FROM analytics.mart_screener_data
+    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]
+)
 SELECT
-    pb.benefit as "Benefit Name",
-    SUM(pb.count) as "# of Screeners",
-    SUM(pb.count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
-FROM analytics.mart_previous_benefits pb
-INNER JOIN filter_keys fk ON pb.partner IS NOT DISTINCT FROM fk.partner AND pb.county IS NOT DISTINCT FROM fk.county
-CROSS JOIN totals t
+    pb.benefit AS "Benefit Name",
+    SUM(pb.count) AS "# of Screeners",
+    SUM(pb.count)::float / NULLIF(MAX(t.total_count), 0) AS "% of Screeners"
+FROM analytics.mart_previous_benefits AS pb
+CROSS JOIN totals AS t
+WHERE EXISTS (
+    SELECT 1
+    FROM analytics.mart_screener_data AS s
+    WHERE s.partner IS NOT DISTINCT FROM pb.partner
+      AND s.county IS NOT DISTINCT FROM pb.county
+      AND 1 = 1
+      [[AND {{submission_date}}]]
+      [[AND {{partner}}]]
+      [[AND {{county}}]]
+)
 GROUP BY pb.benefit
 HAVING SUM(pb.count) > 0
 ORDER BY SUM(pb.count) DESC, pb.benefit ASC

--- a/dashboards/sql/household_head_ages.sql
+++ b/dashboards/sql/household_head_ages.sql
@@ -1,11 +1,17 @@
-WITH filter_keys AS (
-    SELECT DISTINCT partner, county FROM analytics.mart_screener_data WHERE 1=1
-    [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]
-),
-filtered AS (
-    SELECT hm.age FROM analytics.mart_householdmembers hm
-    INNER JOIN filter_keys fk ON hm.partner IS NOT DISTINCT FROM fk.partner AND hm.county IS NOT DISTINCT FROM fk.county
+WITH filtered AS (
+    SELECT hm.age
+    FROM analytics.mart_householdmembers AS hm
     WHERE hm.relationship = 'headOfHousehold'
+      AND EXISTS (
+        SELECT 1
+        FROM analytics.mart_screener_data AS s
+        WHERE s.partner IS NOT DISTINCT FROM hm.partner
+          AND s.county IS NOT DISTINCT FROM hm.county
+          AND 1 = 1
+          [[AND {{submission_date}}]]
+          [[AND {{partner}}]]
+          [[AND {{county}}]]
+      )
 ),
 total AS (
     SELECT count(*) AS n FROM filtered WHERE age IS NOT NULL
@@ -31,6 +37,6 @@ age_bins AS (
 )
 SELECT age_group AS "Age Group",
        count(*)::float / NULLIF(max(t.n), 0) AS "% of Total"
-FROM age_bins, total t
+FROM age_bins, total AS t
 GROUP BY age_group, sort_order
 ORDER BY sort_order

--- a/dashboards/sql/household_member_ages.sql
+++ b/dashboards/sql/household_member_ages.sql
@@ -1,10 +1,16 @@
-WITH filter_keys AS (
-    SELECT DISTINCT partner, county FROM analytics.mart_screener_data WHERE 1=1
-    [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]
-),
-filtered AS (
-    SELECT hm.age FROM analytics.mart_householdmembers hm
-    INNER JOIN filter_keys fk ON hm.partner IS NOT DISTINCT FROM fk.partner AND hm.county IS NOT DISTINCT FROM fk.county
+WITH filtered AS (
+    SELECT hm.age
+    FROM analytics.mart_householdmembers AS hm
+    WHERE EXISTS (
+        SELECT 1
+        FROM analytics.mart_screener_data AS s
+        WHERE s.partner IS NOT DISTINCT FROM hm.partner
+          AND s.county IS NOT DISTINCT FROM hm.county
+          AND 1 = 1
+          [[AND {{submission_date}}]]
+          [[AND {{partner}}]]
+          [[AND {{county}}]]
+      )
 ),
 total AS (
     SELECT count(*) AS n FROM filtered WHERE age IS NOT NULL
@@ -32,6 +38,6 @@ age_bins AS (
 )
 SELECT age_group AS "Age Group",
        count(*)::float / NULLIF(max(t.n), 0) AS "% of Total"
-FROM age_bins, total t
+FROM age_bins, total AS t
 GROUP BY age_group, sort_order
 ORDER BY sort_order

--- a/dashboards/sql/immediate_needs.sql
+++ b/dashboards/sql/immediate_needs.sql
@@ -1,11 +1,26 @@
-WITH totals AS (SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]),
-filter_keys AS (SELECT DISTINCT partner, county FROM analytics.mart_screener_data WHERE 1=1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]])
+-- Immediate needs table: tie aggregated need rows to the same screener population as totals.
+-- Uses EXISTS instead of DISTINCT + INNER JOIN so (partner, county) pairs with NULL county
+-- still match Metabase filters and never drop rows when county is unset (MFB-998).
+WITH totals AS (
+    SELECT count(*) AS total_count
+    FROM analytics.mart_screener_data
+    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]
+)
 SELECT
-    n.benefit as "Need Category",
-    SUM(n.count) as "# of Screeners",
-    SUM(n.count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
-FROM analytics.mart_immediate_needs n
-INNER JOIN filter_keys fk ON n.partner IS NOT DISTINCT FROM fk.partner AND n.county IS NOT DISTINCT FROM fk.county
-CROSS JOIN totals t
+    n.benefit AS "Need Category",
+    SUM(n.count) AS "# of Screeners",
+    SUM(n.count)::float / NULLIF(MAX(t.total_count), 0) AS "% of Screeners"
+FROM analytics.mart_immediate_needs AS n
+CROSS JOIN totals AS t
+WHERE EXISTS (
+    SELECT 1
+    FROM analytics.mart_screener_data AS s
+    WHERE s.partner IS NOT DISTINCT FROM n.partner
+      AND s.county IS NOT DISTINCT FROM n.county
+      AND 1 = 1
+      [[AND {{submission_date}}]]
+      [[AND {{partner}}]]
+      [[AND {{county}}]]
+)
 GROUP BY n.benefit
 ORDER BY SUM(n.count) DESC, n.benefit ASC

--- a/dashboards/sql/qualified_benefits.sql
+++ b/dashboards/sql/qualified_benefits.sql
@@ -1,15 +1,23 @@
 WITH totals AS (
-    SELECT count(*) as total_count FROM analytics.mart_screener_data WHERE 1=1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]
-),
-filter_keys AS (
-    SELECT DISTINCT partner, county FROM analytics.mart_screener_data WHERE 1=1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]
+    SELECT count(*) AS total_count
+    FROM analytics.mart_screener_data
+    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]]
 )
 SELECT
-    qb.benefit as "Benefit Name",
-    SUM(qb.count) as "# of Screeners",
-    SUM(qb.count)::float / NULLIF(MAX(t.total_count), 0) as "% of Screeners"
-FROM analytics.mart_qualified_benefits qb
-INNER JOIN filter_keys fk ON qb.partner IS NOT DISTINCT FROM fk.partner AND qb.county IS NOT DISTINCT FROM fk.county
-CROSS JOIN totals t
+    qb.benefit AS "Benefit Name",
+    SUM(qb.count) AS "# of Screeners",
+    SUM(qb.count)::float / NULLIF(MAX(t.total_count), 0) AS "% of Screeners"
+FROM analytics.mart_qualified_benefits AS qb
+CROSS JOIN totals AS t
+WHERE EXISTS (
+    SELECT 1
+    FROM analytics.mart_screener_data AS s
+    WHERE s.partner IS NOT DISTINCT FROM qb.partner
+      AND s.county IS NOT DISTINCT FROM qb.county
+      AND 1 = 1
+      [[AND {{submission_date}}]]
+      [[AND {{partner}}]]
+      [[AND {{county}}]]
+)
 GROUP BY qb.benefit
 ORDER BY SUM(qb.count) DESC, qb.benefit ASC


### PR DESCRIPTION
## Problem

[MFB-998](https://linear.app/myfriendben/issue/MFB-998/the-urgent-needs-table-isnt-loading-for-texas-unless-a-filter-is) — Texas (and similar) urgent needs table did not load without applying a county filter, often tied to many screeners having **NULL** `county`.

## Cause

Native Metabase SQL used `SELECT DISTINCT partner, county` then `INNER JOIN filter_keys` on `mart_immediate_needs` / `mart_qualified_benefits` / `mart_previous_benefits`. That pattern is easy to break when optional county filters or NULL counties interact badly with how Metabase expands field filters, and it is harder to reason about than filtering directly against the same base table as `totals`.

## Change

For each affected query, **drop `filter_keys`** and instead require:

```sql   WHERE EXISTS (
    SELECT 1 FROM analytics.mart_screener_data AS s
    WHERE s.partner IS NOT DISTINCT FROM n.partner
      AND s.county IS NOT DISTINCT FROM n.county
      AND 1 = 1
      [[AND {{submission_date}}]]
      [[AND {{partner}}]]
      [[AND {{county}}]]
)
```

So every aggregated row is included iff **at least one** screener in the filtered population shares that `(partner, county)` slice (**NULL-safe**).

## Files

- `dashboards/sql/immediate_needs.sql`
- `dashboards/sql/qualified_benefits.sql`
- `dashboards/sql/current_benefits.sql` (`mart_previous_benefits`)
- `dashboards/sql/household_head_ages.sql`
- `dashboards/sql/household_member_ages.sql`

## Deploy

Merge → Terraform apply → Metabase card native queries refresh from `templatefile()` as today.

Made with [Cursor](https://cursor.com)