### PR TITLE
fix(dbt): coalesce NULL county to 'Unspecified' at intermediate layer

### DIFF
--- a/dbt/models/postgres/intermediate/int_complete_screener_data.sql
+++ b/dbt/models/postgres/intermediate/int_complete_screener_data.sql
@@ -37,7 +37,7 @@ WITH base_table_1 AS (
         ss.is_13_or_older,
         ss.last_tax_filing_year,
         ss.zipcode,
-        ss.county,
+        COALESCE(NULLIF(TRIM(ss.county), ''), 'Unspecified') AS county,
         ss.household_assets,
 
         -- Language code mapping - matches data.sql exactly

--- a/dbt/models/postgres/intermediate/int_complete_screener_data.sql
+++ b/dbt/models/postgres/intermediate/int_complete_screener_data.sql
@@ -153,16 +153,16 @@ WITH base_table_1 AS (
         secs.needs_water_heater,
         CASE
             WHEN ss.referral_source ~* '^(testOrProspect|stagingTest|test)$' THEN 'Test'
-            WHEN ss.referrer_code IS NOT NULL AND trim(ss.referrer_code) <> ''
-                THEN coalesce(drc1.partner, 'Other')
-            WHEN ss.referral_source IS NOT NULL AND trim(ss.referral_source) <> ''
-                THEN coalesce(drc2.partner, 'Other')
+            WHEN ss.referrer_code IS NOT NULL AND TRIM(ss.referrer_code) <> ''
+                THEN COALESCE(drc1.partner, 'Other')
+            WHEN ss.referral_source IS NOT NULL AND TRIM(ss.referral_source) <> ''
+                THEN COALESCE(drc2.partner, 'Other')
             ELSE 'No Partner'
         END AS partner,
-        to_char(ss.start_date, 'ID') AS start_day,
-        to_char(ss.start_date, 'HH24') AS start_hour,
-        to_char(ss.submission_date, 'ID') AS submission_day,
-        to_char(ss.submission_date, 'HH24') AS submission_hour,
+        TO_CHAR(ss.start_date, 'ID') AS start_day,
+        TO_CHAR(ss.start_date, 'HH24') AS start_hour,
+        TO_CHAR(ss.submission_date, 'ID') AS submission_day,
+        TO_CHAR(ss.submission_date, 'HH24') AS submission_hour,
         CASE
             WHEN ss.request_language_code = 'af' THEN 'Afrikaans'
             WHEN ss.request_language_code = 'ar' THEN 'Arabic'
@@ -282,10 +282,10 @@ WITH base_table_1 AS (
 benefit_aggregates AS (
     SELECT
         pe.eligibility_snapshot_id,
-        sum(
+        SUM(
             CASE WHEN pe.value_type = 'tax_credit' THEN pe.annual_value ELSE 0 END
         ) AS tax_credits_annual,
-        sum(
+        SUM(
             CASE
                 WHEN pe.value_type IS DISTINCT FROM 'tax_credit'
                     THEN pe.annual_value
@@ -299,8 +299,8 @@ benefit_aggregates AS (
 base_table_2 AS (
     SELECT
         bt1.*,
-        coalesce(ba.non_tax_credit_benefits_annual, 0) AS non_tax_credit_benefits_annual,
-        coalesce(ba.tax_credits_annual, 0) AS tax_credits_annual
+        COALESCE(ba.non_tax_credit_benefits_annual, 0) AS non_tax_credit_benefits_annual,
+        COALESCE(ba.tax_credits_annual, 0) AS tax_credits_annual
     FROM base_table_1 AS bt1
     LEFT JOIN benefit_aggregates AS ba ON bt1.latest_snapshot_id = ba.eligibility_snapshot_id
 )

--- a/dbt/models/postgres/marts/mart_householdmembers.yml
+++ b/dbt/models/postgres/marts/mart_householdmembers.yml
@@ -26,7 +26,7 @@ models:
           - not_null
 
       - name: county
-        description: "County of the head of household."
+        description: "County of the head of household. Null/blank source values are normalized to 'Unspecified'."
         tests:
           - not_null
 

--- a/dbt/models/postgres/marts/mart_householdmembers.yml
+++ b/dbt/models/postgres/marts/mart_householdmembers.yml
@@ -27,6 +27,8 @@ models:
 
       - name: county
         description: "County of the head of household."
+        tests:
+          - not_null
 
       - name: screen_id
         description: "ID of the screener same as screener_id."

--- a/dbt/models/postgres/marts/mart_immediate_needs.yml
+++ b/dbt/models/postgres/marts/mart_immediate_needs.yml
@@ -23,3 +23,8 @@ models:
         description: "Count of people in the corresponding benefit category."
         tests:
           - not_null
+
+      - name: county
+        description: "County grouping dimension. Null/blank source values are normalized to 'Unspecified'."
+        tests:
+          - not_null

--- a/dbt/models/postgres/marts/mart_qualified_benefits.yml
+++ b/dbt/models/postgres/marts/mart_qualified_benefits.yml
@@ -28,3 +28,8 @@ models:
         description: "Number of distinct screeners that qualified for this benefit in the given partner/county group"
         tests:
           - not_null
+
+      - name: county
+        description: "County grouping dimension. Null/blank source values are normalized to 'Unspecified'."
+        tests:
+          - not_null


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

- Fixes #[mfb-1005](https://linear.app/myfriendben/issue/MFB-1005/data-coalesce-null-county-at-the-mart-layer-to-eliminate-null-drift-in)
- Related PR: 

`county` is nullable in `screener_screen` and that nullability propagated through every downstream dbt mart. Dashboard SQL had to work around it with `IS NOT DISTINCT FROM`, which is harder to read and prevents hash-based join optimization in Postgres. The affected white labels are `co_tax_calculator` (100% NULL — never collects county) and `co` (~0.2% NULL from pre-2024-10-14 data and residual FE validation gaps).

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->
<!-- Examples: dbt models added/modified, Terraform resources updated, Metabase container change, scripts added -->

- Added `COALESCE(NULLIF(TRIM(ss.county), ''), 'Unspecified')` in `int_complete_screener_data` — the single upstream source all five affected marts derive county from (mart_screener_data, mart_immediate_needs, `mart_qualified_benefits`, `mart_previous_benefits`, `mart_householdmembers`). No mart-level changes needed.
- Added a `not_null` dbt test on `mart_householdmembers.county` and updated its description to document the '`Unspecified`' placeholder.


## Testing

<!-- Steps needed to test this PR locally -->

- dbt models to run: `dbt run --select int_complete_screener_data`
- Terraform plan reviewed: N/A<!-- paste or link to plan output if applicable -->
- Local Metabase tested via docker-compose:  N/A
- Other manual testing steps:
 Verify NULL county counts drop to 0 after run:

```
SELECT COUNT(*) FROM mart_householdmembers WHERE county IS NULL;
```
-- expect: 0


## Deployment

<!--
Merging to main automatically applies Terraform changes to production.
Metabase container rebuilds and out-of-band dbt runs require manual steps — note them here.
-->

- [ ] Metabase container rebuild/redeploy needed: no
- [x] dbt production run needed (outside nightly cron): yes - run `dbt build --select int_complete_screener_data+` to backfill all downstream marts immediately; otherwise NULL rows persist until the next nightly cron
- [ ] Other post-deployment steps: None

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->
- The placeholder is `Unspecified` (consistent with the existing `county` fallback already present in `int_complete_screener_data` for empty strings). If the team prefers `Unknown` as the ticket suggested, that's a one-word change.
- No dashboard SQL changes are required as a result of this PR, but any existing `IS NOT DISTINCT FROM NULL` county filters in Metabase can be simplified  to ` = 'Unspecified '` after deployment 

- Known limitations: historical rows in `co_tax_calculator` will show `Unspecified` permanently - that white label never collects county by design.
- Future considerations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Normalized county values across datasets: whitespace trimmed and empty values converted to a standardized "Unspecified".
  * Added county column to several data marts and updated descriptions to reflect normalization.
  * Strengthened validation by enforcing non-null checks on county to ensure complete, consistent location data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->