### PR TITLE
Replace regex-on-CURRENT_USER RLS with session GUC + STABLE function (MFB-975)

### DIFF
--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -61,7 +61,7 @@ resource "metabase_database" "tenant_postgres" {
       ssl                = var.database_ssl
       tunnel-enabled     = false
       advanced-options   = true
-      additional-options = "options=-c app.white_label_id=${each.value.white_label_id}"
+      additional-options = "options=-c%20app.white_label_id=${each.value.white_label_id}"
     })
 
     redacted_attributes = [

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -41,6 +41,9 @@ resource "metabase_database" "postgres" {
 }
 
 # Tenant-specific PostgreSQL data sources (RLS filtered access)
+# Each connection sets app.white_label_id via JDBC options so the STABLE
+# mfb_current_white_label_id() function returns the tenant's ID, enabling
+# Postgres to use the white_label_id index instead of seq-scanning (MFB-975).
 resource "metabase_database" "tenant_postgres" {
   for_each = var.tenants
 
@@ -50,14 +53,15 @@ resource "metabase_database" "tenant_postgres" {
     engine = "postgres"
 
     details_json = jsonencode({
-      host             = var.database_host
-      port             = var.database_port
-      dbname           = var.database_name
-      user             = local.tenant_credentials[each.key].username
-      password         = local.tenant_credentials[each.key].password
-      ssl              = var.database_ssl
-      tunnel-enabled   = false
-      advanced-options = false
+      host               = var.database_host
+      port               = var.database_port
+      dbname             = var.database_name
+      user               = local.tenant_credentials[each.key].username
+      password           = local.tenant_credentials[each.key].password
+      ssl                = var.database_ssl
+      tunnel-enabled     = false
+      advanced-options   = true
+      additional-options = "options=-c app.white_label_id=${each.value.white_label_id}"
     })
 
     redacted_attributes = [

--- a/dashboards/terraform.tfvars.example
+++ b/dashboards/terraform.tfvars.example
@@ -12,68 +12,79 @@ global_db_credentials = {
 }
 
 # Tenant-Specific Database Credentials (RLS Users)
-# Convention: wl_<state>_<white_label_id>_ro — the RLS policy extracts the
-# white_label_id from the username via regexp_match(current_user, '^wl_[a-z_]+_([0-9]+)_ro$')
+# Role names still follow wl_<state>_<id>_ro convention for GRANTs/audit, but
+# RLS now uses the session GUC app.white_label_id (set via JDBC options) instead
+# of extracting the ID from the role name.
 tenant_db_credentials = {
   nc = {
-    username = "wl_nc_5_ro"              # white_label_id = 5
+    username = "wl_nc_5_ro"
     password = "your_password"
   }
   co = {
-    username = "wl_co_1_ro"              # white_label_id = 1
+    username = "wl_co_1_ro"
     password = "your_password"
   }
   tx = {
-    username = "wl_tx_40_ro"             # white_label_id = 40
+    username = "wl_tx_40_ro"
     password = "your_password"
   }
   il = {
-    username = "wl_il_39_ro"             # white_label_id = 39
+    username = "wl_il_39_ro"
     password = "your_password"
   }
   ma = {
-    username = "wl_ma_38_ro"             # white_label_id = 38
+    username = "wl_ma_38_ro"
     password = "your_password"
   }
   cesn = {
-    username = "wl_cesn_4_ro"            # white_label_id = 4
+    username = "wl_cesn_4_ro"
     password = "your_password"
   }
   co_tax_calculator = {
-    username = "wl_co_tax_calculator_3_ro"  # white_label_id = 3
+    username = "wl_co_tax_calculator_3_ro"
     password = "your_password"
   }
 }
 
 # Tenant Configuration (Non-sensitive)
+# white_label_id must match the screener_whitelabel.id in the Django database.
+# It is passed to Metabase via JDBC options (-c app.white_label_id=<id>) so the
+# STABLE RLS function can use an index scan instead of a sequential scan.
 tenants = {
   nc = {
-    name         = "nc"
-    display_name = "North Carolina"
+    name           = "nc"
+    display_name   = "North Carolina"
+    white_label_id = 5
   }
   co = {
-    name         = "co"
-    display_name = "Colorado"
+    name           = "co"
+    display_name   = "Colorado"
+    white_label_id = 1
   }
   tx = {
-    name         = "tx"
-    display_name = "Texas"
+    name           = "tx"
+    display_name   = "Texas"
+    white_label_id = 40
   }
   il = {
-    name         = "il"
-    display_name = "Illinois"
+    name           = "il"
+    display_name   = "Illinois"
+    white_label_id = 39
   }
   ma = {
-    name         = "ma"
-    display_name = "Massachusetts"
+    name           = "ma"
+    display_name   = "Massachusetts"
+    white_label_id = 38
   }
   cesn = {
-    name         = "cesn"
-    display_name = "CESN"
+    name           = "cesn"
+    display_name   = "CESN"
+    white_label_id = 4
   }
   co_tax_calculator = {
-    name         = "co_tax_calculator"
-    display_name = "CO Tax Calculator"
+    name           = "co_tax_calculator"
+    display_name   = "CO Tax Calculator"
+    white_label_id = 3
   }
 }
 

--- a/dashboards/variables.tf
+++ b/dashboards/variables.tf
@@ -32,6 +32,17 @@ variable "tenants" {
     display_name   = string
     white_label_id = number
   }))
+
+  validation {
+    condition     = alltrue([for t in var.tenants : t.white_label_id > 0 && floor(t.white_label_id) == t.white_label_id])
+    error_message = "Each tenant white_label_id must be a positive integer."
+  }
+
+  validation {
+    condition     = length(distinct([for t in var.tenants : t.white_label_id])) == length(var.tenants)
+    error_message = "Each tenant must have a unique white_label_id."
+  }
+
   default = {
     nc = {
       name           = "nc"

--- a/dashboards/variables.tf
+++ b/dashboards/variables.tf
@@ -28,37 +28,45 @@ variable "global_db_credentials" {
 variable "tenants" {
   description = "Map of tenant configurations (non-sensitive)"
   type = map(object({
-    name         = string
-    display_name = string
+    name           = string
+    display_name   = string
+    white_label_id = number
   }))
   default = {
     nc = {
-      name         = "nc"
-      display_name = "North Carolina"
+      name           = "nc"
+      display_name   = "North Carolina"
+      white_label_id = 5
     }
     co = {
-      name         = "co"
-      display_name = "Colorado"
+      name           = "co"
+      display_name   = "Colorado"
+      white_label_id = 1
     }
     tx = {
-      name         = "tx"
-      display_name = "Texas"
+      name           = "tx"
+      display_name   = "Texas"
+      white_label_id = 40
     }
     il = {
-      name         = "il"
-      display_name = "Illinois"
+      name           = "il"
+      display_name   = "Illinois"
+      white_label_id = 39
     }
     ma = {
-      name         = "ma"
-      display_name = "Massachusetts"
+      name           = "ma"
+      display_name   = "Massachusetts"
+      white_label_id = 38
     }
     cesn = {
-      name         = "cesn"
-      display_name = "CESN"
+      name           = "cesn"
+      display_name   = "CESN"
+      white_label_id = 4
     }
     co_tax_calculator = {
-      name         = "co_tax_calculator"
-      display_name = "CO Tax Calculator"
+      name           = "co_tax_calculator"
+      display_name   = "CO Tax Calculator"
+      white_label_id = 3
     }
   }
 }

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -4,7 +4,13 @@ profile: benefits
 require-dbt-version: ">=1.7.0,<2.0.0"
 
 on-run-start:
+  - "{{ ensure_mfb_current_white_label_id_function() }}"
   - "{{ enforce_rls_on_marts() }}"
+
+vars:
+  # RLS on postgres marts: session_guc (app.white_label_id — index-friendly, MFB-975)
+  # Previously regex_user (role name); switched to session_guc to enable index scans.
+  mfb_rls_policy_mode: session_guc
 
 model-paths: ["models"]
 analysis-paths: ["analyses"]

--- a/dbt/macros/mfb_current_white_label_id_function.sql
+++ b/dbt/macros/mfb_current_white_label_id_function.sql
@@ -1,0 +1,29 @@
+{#
+  Session variable helper for index-friendly RLS (Benefits / Metabase dashboards).
+
+  Prefer `vars.mfb_rls_policy_mode: session_guc` in dbt_project.yml only after the
+  warehouse client (e.g. Metabase) runs per session:
+
+    SELECT set_config('app.white_label_id', '<id>', false);
+
+  See dashboards/sql/BENEFITS_TAB_PLAN_AND_RLS.md and dashboards/sql/tests/benefits_tab_queries/reproduce_issue.sh
+#}
+
+{% macro ensure_mfb_current_white_label_id_function() %}
+  {% if target.type != 'postgres' %}
+    {{ return('') }}
+  {% endif %}
+
+  CREATE OR REPLACE FUNCTION {{ target.schema }}.mfb_current_white_label_id()
+  RETURNS integer
+  LANGUAGE sql
+  STABLE
+  PARALLEL SAFE
+  SET search_path = ''
+  AS $fn$
+    SELECT (NULLIF(TRIM(BOTH FROM current_setting('app.white_label_id', true)), ''))::integer
+  $fn$;
+
+  GRANT EXECUTE ON FUNCTION {{ target.schema }}.mfb_current_white_label_id() TO PUBLIC;
+
+{% endmacro %}

--- a/dbt/macros/mfb_current_white_label_id_function.sql
+++ b/dbt/macros/mfb_current_white_label_id_function.sql
@@ -1,12 +1,21 @@
 {#
   Session variable helper for index-friendly RLS (Benefits / Metabase dashboards).
 
-  Prefer `vars.mfb_rls_policy_mode: session_guc` in dbt_project.yml only after the
-  warehouse client (e.g. Metabase) runs per session:
+  Enabled via `vars.mfb_rls_policy_mode: session_guc` in dbt_project.yml. Each
+  tenant's GUC is set once per connection by Metabase via JDBC options
+  (`options=-c app.white_label_id=<id>`, configured in dashboards/metabase.tf).
+  Postgres applies the option at connect time, so the GUC is available before
+  any query runs — no per-query `set_config()` call is required.
+
+  For ad-hoc testing outside Metabase (e.g. psql), set the GUC manually:
 
     SELECT set_config('app.white_label_id', '<id>', false);
 
-  See dashboards/sql/BENEFITS_TAB_PLAN_AND_RLS.md and dashboards/sql/tests/benefits_tab_queries/reproduce_issue.sh
+  Security note: custom GUCs (`app.*`) are user-settable by default in Postgres,
+  so any role with native-SQL access could `SET app.white_label_id = <other_id>`
+  to bypass RLS. Tenant isolation depends on Metabase native-query access being
+  restricted to the Administrators group — preserve this invariant when adding
+  new tenant groups.
 #}
 
 {% macro ensure_mfb_current_white_label_id_function() %}

--- a/dbt/macros/row_level_security.sql
+++ b/dbt/macros/row_level_security.sql
@@ -1,11 +1,8 @@
 /*
-  Row Level Security (RLS) macro for white label filtering
+  Row Level Security (RLS) macro for white label filtering.
 
-  Performance / planner interaction with Metabase native SQL (Benefits tab, etc.):
-  see dashboards/sql/BENEFITS_TAB_PLAN_AND_RLS.md
-
-  This macro creates database policies that restrict users to only see data
-  for their associated white label.
+  Creates database policies that restrict users to only see data for their
+  associated white label.
 
   Usage:
     setup_white_label_rls('table_name', 'white_label_id_column')
@@ -18,9 +15,15 @@
   Var (dbt_project.yml):
     mfb_rls_policy_mode: regex_user | session_guc
 
-    session_guc: policy uses mfb_current_white_label_id() in the target schema (STABLE, reads
-    app.white_label_id). Connections must set it once per session, e.g.:
-      SELECT set_config('app.white_label_id', '<white_label_id>', false);
+    session_guc (current, MFB-975): policy uses mfb_current_white_label_id() —
+    a STABLE function that reads the `app.white_label_id` session GUC. Metabase
+    sets the GUC at JDBC connect time via `options=-c app.white_label_id=<id>`.
+    Index-friendly: Postgres can fold the function to a constant and use the
+    white_label_id btree index.
+
+    regex_user (legacy): policy extracts the ID from `current_user` via regex
+    (`wl_<state>_<id>_ro`). Not index-friendly — forces seq scans. Kept as
+    fallback in case the GUC setup needs to be rolled back.
 */
 
 {% macro setup_white_label_rls(table_name, white_label_column='white_label_id', schema_name=none) %}
@@ -47,12 +50,9 @@
   -- Drop existing policy if it exists
   DROP POLICY IF EXISTS {{ policy_name }} ON {{ full_table_name }};
 
-  -- Create RLS policy that extracts white_label_id from the username
-  -- Convention: credential names follow wl_<state>_<id>_ro (e.g. wl_nc_5_ro → 5)
-  -- Table owners (dbt build user) bypass RLS automatically in PostgreSQL
-  -- Non-conforming role names yield NULL → no rows (safe denial)
-  --
-  -- Mode session_guc: see ensure_mfb_current_white_label_id_function() + var mfb_rls_policy_mode
+  -- Table owners (dbt build user) bypass RLS automatically in PostgreSQL.
+  -- Non-conforming role names (regex_user mode) or missing GUC (session_guc
+  -- mode) yield NULL → no rows (safe denial).
   CREATE POLICY {{ policy_name }}
     ON {{ full_table_name }}
     FOR ALL

--- a/dbt/macros/row_level_security.sql
+++ b/dbt/macros/row_level_security.sql
@@ -1,16 +1,26 @@
 /*
   Row Level Security (RLS) macro for white label filtering
 
+  Performance / planner interaction with Metabase native SQL (Benefits tab, etc.):
+  see dashboards/sql/BENEFITS_TAB_PLAN_AND_RLS.md
+
   This macro creates database policies that restrict users to only see data
   for their associated white label.
 
   Usage:
-    {{ setup_white_label_rls('table_name', 'white_label_id_column') }}
+    setup_white_label_rls('table_name', 'white_label_id_column')
 
   Parameters:
     - table_name: The name of the table to apply RLS to
     - white_label_column: The column name containing white label IDs (default: 'white_label_id')
     - schema_name: Optional schema name (default: current schema)
+
+  Var (dbt_project.yml):
+    mfb_rls_policy_mode: regex_user | session_guc
+
+    session_guc: policy uses mfb_current_white_label_id() in the target schema (STABLE, reads
+    app.white_label_id). Connections must set it once per session, e.g.:
+      SELECT set_config('app.white_label_id', '<white_label_id>', false);
 */
 
 {% macro setup_white_label_rls(table_name, white_label_column='white_label_id', schema_name=none) %}
@@ -20,6 +30,16 @@
   {% endset %}
 
   {% set policy_name %}rls_white_label_{{ table_name }}{% endset %}
+
+  {% set rls_mode = var('mfb_rls_policy_mode', 'regex_user') %}
+
+  {% set using_clause %}
+    {% if rls_mode == 'session_guc' %}
+      {{ white_label_column }} = {{ target.schema }}.mfb_current_white_label_id()
+    {% else %}
+      {{ white_label_column }} = (regexp_match(current_user, '^wl_[a-z_]+_([0-9]+)_ro$'))[1]::int
+    {% endif %}
+  {% endset %}
 
   -- Enable RLS on the table
   ALTER TABLE {{ full_table_name }} ENABLE ROW LEVEL SECURITY;
@@ -31,12 +51,14 @@
   -- Convention: credential names follow wl_<state>_<id>_ro (e.g. wl_nc_5_ro → 5)
   -- Table owners (dbt build user) bypass RLS automatically in PostgreSQL
   -- Non-conforming role names yield NULL → no rows (safe denial)
+  --
+  -- Mode session_guc: see ensure_mfb_current_white_label_id_function() + var mfb_rls_policy_mode
   CREATE POLICY {{ policy_name }}
     ON {{ full_table_name }}
     FOR ALL
     TO PUBLIC
     USING (
-      {{ white_label_column }} = (regexp_match(current_user, '^wl_[a-z_]+_([0-9]+)_ro$'))[1]::int
+      {{ using_clause }}
     );
 
   -- Grant necessary permissions


### PR DESCRIPTION
## Summary

Fixes [MFB-998](https://linear.app/myfriendben/issue/MFB-998) (parent: [MFB-975](https://linear.app/myfriendben/issue/MFB-975)): Metabase urgent needs / qualified benefits / current benefits charts not loading for Texas.

The `regexp_match(current_user)` RLS policy prevented Postgres from using the `white_label_id` btree index, forcing seq scans on every dashboard query. For tenants where the planner picked a nested loop (TX hit this around 136 screeners with 8 partners × 18 counties), queries exceeded Metabase's ~30s timeout → 503s.

**Fix:** Replace the regex RLS with a `STABLE` function `mfb_current_white_label_id()` that reads `app.white_label_id` from a session GUC. Each Metabase tenant connection sets the GUC at connect time via JDBC `options=-c app.white_label_id=<id>`. Postgres evaluates the function once per statement and uses the btree index — seq scans collapse to index scans across all dashboard queries.

### What changed

- **`dbt/macros/mfb_current_white_label_id_function.sql`** — new `STABLE`, `PARALLEL SAFE` function installed via `on-run-start`, with locked `search_path = ''`
- **`dbt/macros/row_level_security.sql`** — dual-mode support (`regex_user` | `session_guc`); policy becomes `USING (white_label_id = mfb_current_white_label_id())`
- **`dbt/dbt_project.yml`** — sets `mfb_rls_policy_mode: session_guc`, adds function to `on-run-start`
- **`dashboards/metabase.tf`** — tenant connections pass `additional-options = "options=-c app.white_label_id=<id>"` via JDBC
- **`dashboards/variables.tf`** — adds `white_label_id` to `tenants` object type, with `validation` blocks (positive integer, unique)
- **`dashboards/terraform.tfvars.example`** — updated with `white_label_id` values per tenant

### Scope of impact

The fix is applied at the RLS macro layer, which runs against every mart via `enforce_rls_on_marts()` in `on-run-start`. **All 10 mart tables get the new policy on the next `dbt build`** — not just the three that were timing out for TX. Every dashboard card that filters on `white_label_id` (which is effectively all of them) benefits from index access instead of seq scans:

`mart_screener_data`, `mart_immediate_needs`, `mart_qualified_benefits`, `mart_previous_benefits`, `mart_current_benefits`, `mart_householdmembers`, `mart_income`, `mart_screener_expense`, `mart_referrer_codes`, `mart_programs_value_types`

### Benchmarks (Texas tenant, before / after)

API endpoint (card) | Dashboard tile | Before | After
-- | -- | -- | --
/card/62/query | "What percentage of completed screeners qualified for benefits?" | 30.1s → 503 | 10ms
/card/84/query | "What percentage of users already had certain benefits?" | 30.1s → 503 | 51ms
/card/56/query | "What percentage of users sought each immediate need?" | 30.1s → 503 | 14ms

Those are the `qualified_benefits`, `current_benefits`, and `immediate_needs` queries that hit the Heroku 30s router timeout and return `503 Service Unavailable` (the grey skeleton placeholders that never load). After the fix, all three complete under 52ms. Other dashboards across all tenants should see proportional speedups (smaller queries proportionally smaller wins).

### Security note (re tenant isolation)

Custom GUCs (`app.*`) are user-settable by default in Postgres, so any role with native-SQL access could `SET app.white_label_id = <other_id>` to bypass RLS mid-session. **Tenant isolation depends on Metabase native-query access being restricted to the Administrators group.**

Verified in Metabase Admin → Permissions: only the Administrators group has "Query builder and native" access to tenant DBs. All tenant-specific groups (Colorado Editors, Texas Viewers, etc.) have either "Query builder only" (on their own DB) or "No" (on other tenants' DBs). Preserve this invariant when adding new tenant groups — the macro comment in [`dbt/macros/mfb_current_white_label_id_function.sql`](dbt/macros/mfb_current_white_label_id_function.sql) calls this out.

This is not a regression from the old regex policy — that one was also bypassable by anyone with `SET ROLE` privileges. Different shape of escape hatch, same access surface.

### Deployment & verification

**Deployment is automatic on merge:**

1. **Merge this PR** → triggers `dbt-on-merge` workflow which runs `dbt build` on production. This installs the function and rebuilds RLS policies on all 10 mart tables to use the GUC.
2. **Terraform apply** (auto-triggered by merge) → updates Metabase tenant DB connections with the JDBC `options` parameter.

Both workflows run on merge to `main`, so no manual steps are needed. The GUC is set at JDBC connect time, so existing Metabase sessions will pick it up on next connection pool refresh.

**Post-merge verification** — after both workflows complete, run this against the analytics database to confirm every policy was rewritten to the GUC-based form:

```sql
SELECT schemaname, tablename, policyname, qual
FROM pg_policies
WHERE schemaname = 'analytics'
ORDER BY tablename;
```

Expected: all 10 rows show `qual` containing `mfb_current_white_label_id()`. If any row still shows `regexp_match(...)`, the dbt build didn't rebuild that mart's policy — investigate before considering the deploy complete.

Then load the Texas dashboard in Metabase and confirm the three previously-timing-out cards load within seconds.

### Rollback

Flip `mfb_rls_policy_mode: session_guc` back to `regex_user` in `dbt/dbt_project.yml`, re-run `dbt build`. The regex-based policy is kept in the macro for exactly this fallback path. Metabase JDBC options can stay in place — they're harmless when the policy doesn't read them.

## Test plan

- [ ] `dbt build --target postgres` succeeds locally (installs function + rebuilds policies)
- [ ] RLS works with GUC: `SET ROLE wl_tx_40_ro; SELECT set_config('app.white_label_id', '40', false); SELECT count(*) FROM analytics.mart_screener_data;` returns only TX rows
- [ ] After merge: `pg_policies` verification query shows all 10 marts on the new policy
- [ ] After merge: Texas urgent needs, qualified benefits, and current benefits charts load in Metabase production within seconds

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-based tenant identification via a JDBC session setting for query-time tenant selection.
  * Configurable RLS mode allowing selection between session-GUC and role-name strategies.
  * Automated creation of a small DB helper to read the session tenant value.

* **Chores**
  * Updated Terraform and example configs to include numeric tenant IDs and validations.
  * Connection settings updated to inject the session tenant value for each tenant.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/data-queries/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->