### PR TITLE
Add mart_current_benefits sourced from join table, swap dashboard card (MFB-867)

### DIFF
--- a/dashboards/sql/current_benefits.sql
+++ b/dashboards/sql/current_benefits.sql
@@ -15,18 +15,18 @@ filter_keys AS (
 )
 
 SELECT
-    pb.benefit AS "Benefit Name",
-    sum(pb.count) AS "# of Screeners",
-    sum(pb.count)::FLOAT / nullif(max(t.total_count), 0) AS "% of Screeners"
-FROM analytics.mart_previous_benefits pb
+    cb.benefit_display_name AS "Benefit Name",
+    count(DISTINCT cb.screen_id) AS "# of Screeners",
+    count(DISTINCT cb.screen_id)::FLOAT / nullif(max(t.total_count), 0) AS "% of Screeners"
+FROM analytics.mart_current_benefits cb
 INNER JOIN filter_keys fk
     ON
-        pb.partner IS NOT DISTINCT FROM fk.partner
-        AND pb.county IS NOT DISTINCT FROM fk.county
-        AND pb.utm_campaign IS NOT DISTINCT FROM fk.utm_campaign
-        AND pb.utm_medium IS NOT DISTINCT FROM fk.utm_medium
-        AND pb.utm_source IS NOT DISTINCT FROM fk.utm_source
+        cb.partner IS NOT DISTINCT FROM fk.partner
+        AND cb.county IS NOT DISTINCT FROM fk.county
+        AND cb.utm_campaign IS NOT DISTINCT FROM fk.utm_campaign
+        AND cb.utm_medium IS NOT DISTINCT FROM fk.utm_medium
+        AND cb.utm_source IS NOT DISTINCT FROM fk.utm_source
 CROSS JOIN totals t
-GROUP BY pb.benefit
-HAVING sum(pb.count) > 0
-ORDER BY sum(pb.count) DESC, pb.benefit ASC
+GROUP BY cb.benefit_display_name
+HAVING count(DISTINCT cb.screen_id) > 0
+ORDER BY count(DISTINCT cb.screen_id) DESC, cb.benefit_display_name ASC

--- a/dashboards/sql/current_benefits.sql
+++ b/dashboards/sql/current_benefits.sql
@@ -15,7 +15,7 @@ filter_keys AS (
 )
 
 SELECT
-    cb.benefit_display_name AS "Benefit Name",
+    max(cb.benefit_display_name) AS "Benefit Name",
     count(DISTINCT cb.screen_id) AS "# of Screeners",
     count(DISTINCT cb.screen_id)::FLOAT / nullif(max(t.total_count), 0) AS "% of Screeners"
 FROM analytics.mart_current_benefits cb
@@ -27,6 +27,6 @@ INNER JOIN filter_keys fk
         AND cb.utm_medium IS NOT DISTINCT FROM fk.utm_medium
         AND cb.utm_source IS NOT DISTINCT FROM fk.utm_source
 CROSS JOIN totals t
-GROUP BY cb.benefit_display_name
+GROUP BY cb.benefit_name
 HAVING count(DISTINCT cb.screen_id) > 0
-ORDER BY count(DISTINCT cb.screen_id) DESC, cb.benefit_display_name ASC
+ORDER BY count(DISTINCT cb.screen_id) DESC, max(cb.benefit_display_name) ASC

--- a/dbt/models/postgres/marts/mart_current_benefits.sql
+++ b/dbt/models/postgres/marts/mart_current_benefits.sql
@@ -1,0 +1,28 @@
+{{
+  config(
+    materialized='table',
+    post_hook="{{ setup_white_label_rls(this.name) }}",
+    description='One row per screen × benefit sourced from the screener_current_benefits join table. Replaces the old has_* column approach.'
+  )
+}}
+
+SELECT
+    cb.screen_id,
+    pp.white_label_id,
+    msd.partner,
+    msd.county,
+    msd.submission_date,
+    msd.utm_campaign,
+    msd.utm_medium,
+    msd.utm_source,
+    pp.name_abbreviated AS benefit_name,
+    COALESCE(pn.text, pp.name_abbreviated) AS benefit_display_name
+FROM {{ ref('stg_current_benefits') }} AS cb
+INNER JOIN {{ source('django_apps', 'programs_program') }} AS pp
+    ON cb.program_id = pp.id
+INNER JOIN {{ ref('mart_screener_data') }} AS msd
+    ON cb.screen_id = msd.id
+    AND msd.white_label_id = pp.white_label_id
+LEFT JOIN {{ source('django_apps', 'translations_translation_translation') }} AS pn
+    ON pp.name_id = pn.master_id
+    AND pn.language_code = 'en-us'

--- a/dbt/models/postgres/marts/mart_current_benefits.sql
+++ b/dbt/models/postgres/marts/mart_current_benefits.sql
@@ -22,7 +22,7 @@ INNER JOIN {{ source('django_apps', 'programs_program') }} AS pp
     ON cb.program_id = pp.id
 INNER JOIN {{ ref('mart_screener_data') }} AS msd
     ON cb.screen_id = msd.id
-    AND msd.white_label_id = pp.white_label_id
+    AND pp.white_label_id = msd.white_label_id
 LEFT JOIN {{ source('django_apps', 'translations_translation_translation') }} AS pn
     ON pp.name_id = pn.master_id
     AND pn.language_code = 'en-us'

--- a/dbt/models/postgres/marts/mart_current_benefits.sql
+++ b/dbt/models/postgres/marts/mart_current_benefits.sql
@@ -1,8 +1,7 @@
 {{
   config(
     materialized='table',
-    post_hook="{{ setup_white_label_rls(this.name) }}",
-    description='One row per screen × benefit sourced from the screener_current_benefits join table. Replaces the old has_* column approach.'
+    post_hook="{{ setup_white_label_rls(this.name) }}"
   )
 }}
 

--- a/dbt/models/postgres/marts/mart_current_benefits.sql
+++ b/dbt/models/postgres/marts/mart_current_benefits.sql
@@ -22,6 +22,10 @@ INNER JOIN {{ source('django_apps', 'programs_program') }} AS pp
     ON cb.program_id = pp.id
 INNER JOIN {{ ref('mart_screener_data') }} AS msd
     ON cb.screen_id = msd.id
+    -- Defensive: also require the program's white_label to match the screen's.
+    -- Silently drops any anomalous join-table rows that point at a program from
+    -- a different white_label than the screen (should never happen, but safer
+    -- to drop than to leak across WL boundaries).
     AND pp.white_label_id = msd.white_label_id
 LEFT JOIN {{ source('django_apps', 'translations_translation_translation') }} AS pn
     ON pp.name_id = pn.master_id

--- a/dbt/models/postgres/marts/mart_current_benefits.yml
+++ b/dbt/models/postgres/marts/mart_current_benefits.yml
@@ -4,6 +4,9 @@ models:
   - name: mart_current_benefits
     description: "One row per screen × benefit, sourced from the screener_current_benefits join table (replaces the legacy screener_screen.has_* columns dropped in MFB-720)."
     tests:
+      # Grain depends on the `pp.white_label_id = msd.white_label_id` filter in the
+      # model: without it, a single screen could pull in two programs_program rows
+      # sharing the same name_abbreviated across white labels and break uniqueness.
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - screen_id

--- a/dbt/models/postgres/marts/mart_current_benefits.yml
+++ b/dbt/models/postgres/marts/mart_current_benefits.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: mart_current_benefits
-    description: "One row per screen × benefit sourced from the screener_current_benefits join table. Replaces the old has_* column approach."
+    description: "One row per screen × benefit, sourced from the screener_current_benefits join table (replaces the legacy screener_screen.has_* columns dropped in MFB-720)."
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
@@ -43,6 +43,6 @@ models:
           - not_null
 
       - name: benefit_display_name
-        description: "English (en-us) display name for the benefit program. Falls back to benefit_name if no translation exists."
+        description: "English (en-us) display name for the benefit program from this row's white label. Falls back to benefit_name if no translation exists. Under RLS (per-WL queries, the default), all rows for a given benefit_name share the same display name. In any cross-WL query, display names may differ across white labels — pick a deterministic tiebreaker (e.g. MIN(white_label_id)) at the query site."
         tests:
           - not_null

--- a/dbt/models/postgres/marts/mart_current_benefits.yml
+++ b/dbt/models/postgres/marts/mart_current_benefits.yml
@@ -3,6 +3,11 @@ version: 2
 models:
   - name: mart_current_benefits
     description: "One row per screen × benefit sourced from the screener_current_benefits join table. Replaces the old has_* column approach."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - screen_id
+            - benefit_name
     columns:
       - name: screen_id
         description: "Foreign key to screener_screen"
@@ -15,22 +20,22 @@ models:
           - not_null
 
       - name: partner
-        description: "Referral partner associated with the screener"
+        description: "Referral partner associated with the screener. Passed through from mart_screener_data."
 
       - name: county
-        description: "County associated with the screener"
+        description: "County associated with the screener. Passed through from mart_screener_data."
 
       - name: submission_date
-        description: "Date the screener was submitted"
+        description: "Date the screener was submitted. Passed through from mart_screener_data."
 
       - name: utm_campaign
-        description: "UTM campaign parameter from the screener"
+        description: "UTM campaign parameter from the screener. Passed through from mart_screener_data."
 
       - name: utm_medium
-        description: "UTM medium parameter from the screener"
+        description: "UTM medium parameter from the screener. Passed through from mart_screener_data."
 
       - name: utm_source
-        description: "UTM source parameter from the screener"
+        description: "UTM source parameter from the screener. Passed through from mart_screener_data."
 
       - name: benefit_name
         description: "Language-agnostic program slug (e.g. 'snap', 'wic'). Use for grouping to avoid translation duplicates."

--- a/dbt/models/postgres/marts/mart_current_benefits.yml
+++ b/dbt/models/postgres/marts/mart_current_benefits.yml
@@ -1,0 +1,43 @@
+version: 2
+
+models:
+  - name: mart_current_benefits
+    description: "One row per screen × benefit sourced from the screener_current_benefits join table. Replaces the old has_* column approach."
+    columns:
+      - name: screen_id
+        description: "Foreign key to screener_screen"
+        tests:
+          - not_null
+
+      - name: white_label_id
+        description: "White label organization ID used for row-level security"
+        tests:
+          - not_null
+
+      - name: partner
+        description: "Referral partner associated with the screener"
+
+      - name: county
+        description: "County associated with the screener"
+
+      - name: submission_date
+        description: "Date the screener was submitted"
+
+      - name: utm_campaign
+        description: "UTM campaign parameter from the screener"
+
+      - name: utm_medium
+        description: "UTM medium parameter from the screener"
+
+      - name: utm_source
+        description: "UTM source parameter from the screener"
+
+      - name: benefit_name
+        description: "Language-agnostic program slug (e.g. 'snap', 'wic'). Use for grouping to avoid translation duplicates."
+        tests:
+          - not_null
+
+      - name: benefit_display_name
+        description: "English (en-us) display name for the benefit program. Falls back to benefit_name if no translation exists."
+        tests:
+          - not_null

--- a/dbt/models/postgres/marts/mart_qualified_benefits.sql
+++ b/dbt/models/postgres/marts/mart_qualified_benefits.sql
@@ -1,8 +1,7 @@
 {{
   config(
     materialized='table',
-    post_hook="{{ setup_white_label_rls(this.name) }}",
-    description='Materialized mart of per-program eligibility counts by partner and county. Dynamic: joins stg_program_eligibility directly, so new programs are included automatically without code changes.'
+    post_hook="{{ setup_white_label_rls(this.name) }}"
   )
 }}
 

--- a/dbt/models/postgres/marts/mart_qualified_benefits.yml
+++ b/dbt/models/postgres/marts/mart_qualified_benefits.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: mart_qualified_benefits
-    description: "Materialized mart that unpivots benefit eligibility data into rows for easier dashboarding. Contains counts of people who qualified for each benefit category by white_label_id and partner."
+    description: "Materialized mart that unpivots benefit eligibility data into rows for easier dashboarding. Contains counts of people who qualified for each benefit category by white_label_id and partner. Dynamic: joins stg_program_eligibility directly, so new programs are included automatically without code changes."
     columns:
       - name: white_label_id
         description: "White label organization ID used for row-level security"


### PR DESCRIPTION
## Context & Motivation

- Linear: [MFB-867 — CB Step 4: dbt new mart_current_benefits, validate, and swap dashboard card](https://linear.app/myfriendben/issue/MFB-867/cb-step-4-dbt-new-mart-current-benefits-validate-and-swap-dashboard)

Replaces the old `mart_current_benefits` (which was sourced from `has_*` columns on `screener_screen`) with a new version driven by the `screener_current_benefits` join table (`stg_current_benefits`). The join-table approach is the source of truth going forward; the `has_*` columns are legacy. This also swaps the `current_benefits.sql` Metabase dashboard card to query the new mart.

Note: the old `analytics.mart_current_benefits` Postgres table was dropped during PR #94 post-deploy cleanup (the dbt model had already been removed in PR #80, but the table was intentionally left as a validation baseline — it was dropped before that context was known). Validation is therefore against `screener_screen.has_*` columns directly rather than the old table.

## Changes Made

- **`dbt/models/postgres/marts/mart_current_benefits.sql`** (new): Materialized table, grain = one row per screen × benefit. Joins `stg_current_benefits` → `programs_program` → `mart_screener_data` (for partner/county/utm/submission_date) → `translations_translation_translation` (for English display name). Standard `setup_white_label_rls` post-hook.
- **`dbt/models/postgres/marts/mart_current_benefits.yml`** (new): Schema docs, `not_null` tests on `screen_id`, `white_label_id`, `benefit_name`, `benefit_display_name`, and a `dbt_utils.unique_combination_of_columns` test on `[screen_id, benefit_name]` to enforce the stated grain. The grain test relies on the model's defensive `pp.white_label_id = msd.white_label_id` filter — a comment in the yml documents that dependency so a future loosening of the filter doesn't silently break the test.
- **`dashboards/sql/current_benefits.sql`** (modified): Points at `analytics.mart_current_benefits` instead of `analytics.mart_previous_benefits`. Uses `COUNT(DISTINCT screen_id)` instead of `SUM(count)` since the new mart is screen-level rows. Groups by `benefit_name` (slug) with `MAX(benefit_display_name)` as the label, per the yml's own guidance on grouping.
- **`dbt/models/postgres/marts/mart_qualified_benefits.{sql,yml}`** (CR follow-up): Removed the `description='...'` kwarg from `config(...)` — not a recognized dbt model config key; descriptions belong in the yml. Folded the previously-SQL-only "Dynamic: joins stg_program_eligibility directly" nuance into the yml description so no info is lost. Same `description=` cleanup applied to `mart_current_benefits.sql`.

## Testing

- dbt models to run locally:
  ```
  dbt build --select mart_current_benefits
  ```
- Validate counts locally — aggregate by `benefit_name + white_label_id + partner` and compare to `screener_screen WHERE has_<benefit> = true`, sampled across CO/TX/NC. Minor deltas expected for SSI and CHP per milestone notes.
- Once counts confirmed locally, deploy to production.

## Deployment

- [ ] Metabase container rebuild/redeploy needed: no
- [ ] dbt production run needed (outside nightly cron): yes — run `mart_current_benefits` on production after merge (the dashboard card will error until the mart exists)
- [ ] Other post-deployment steps: Spot-check dashboard card numbers in production after the dbt run.

## Notes for Reviewers

- The dashboard SQL change switches from `SUM(pb.count)` (pre-aggregated) to `COUNT(DISTINCT cb.screen_id)` (row-level) — semantically equivalent but requires the mart to be built first before the dashboard card works.
- `benefit_display_name` falls back to `benefit_name` (the slug) via `COALESCE` if no `en-us` translation exists, matching the same pattern in `mart_qualified_benefits`.
- The `pp.white_label_id = msd.white_label_id` join condition is correct RLS-safe behavior and matches `mart_qualified_benefits`. Cross-WL rows can't exist by construction (the screening flow only surfaces programs scoped to the screen's white label), so this join won't silently drop real data.
- Known limitations: Validation is against live `screener_screen.has_*` columns since the old mart table was dropped in PR #94 — see MFB-867 comments for full context.
- Future considerations / milestone-scope updates made during this review:
  - **MFB-872** (Step 9b — dbt cleanup) updated to explicitly cover deletion of `int_previous_benefits.sql` + `mart_previous_benefits.sql` (no consumers after this PR) and `has_*` passthroughs in `int_complete_screener_data.sql`, with a zero-`has_*`-refs grep acceptance criterion. This closes the dbt side of the `has_*` retirement so the MFB-878 column drop doesn't break the nightly dbt run.
  - **MFB-878** (Step 7 — DB column drop) updated to also retire the v1 `data-queries/` legacy SQL (`data_previous_benefits.sql` + `reference_data_*_previous_benefits` materialized views in `refresh_v1_dashboards.sql`, ~64 `has_<benefit>` refs), with a same-day-merge coordination note for MFB-872.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced current benefits reporting with new metrics including distinct screener count and benefit display names for improved visibility into benefit usage.

* **Documentation**
  * Added comprehensive schema documentation for the current benefits data model, including grain specifications and validation rules.
  * Enhanced documentation for qualified benefits model to clarify dynamic program inclusion behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyFriendBen/data-queries/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->