### PR TITLE
Fix dashboard card perf: drop filter_keys null-safe self-join (MFB-867 follow-up)

### DIFF
--- a/dashboards/sql/current_benefits.sql
+++ b/dashboards/sql/current_benefits.sql
@@ -1,17 +1,6 @@
 WITH totals AS (
     SELECT count(*) AS total_count FROM analytics.mart_screener_data
     WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
-),
-
-filter_keys AS (
-    SELECT DISTINCT
-        partner,
-        county,
-        utm_campaign,
-        utm_medium,
-        utm_source
-    FROM analytics.mart_screener_data
-    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 )
 
 SELECT
@@ -19,14 +8,8 @@ SELECT
     count(DISTINCT cb.screen_id) AS "# of Screeners",
     count(DISTINCT cb.screen_id)::FLOAT / nullif(max(t.total_count), 0) AS "% of Screeners"
 FROM analytics.mart_current_benefits cb
-INNER JOIN filter_keys fk
-    ON
-        cb.partner IS NOT DISTINCT FROM fk.partner
-        AND cb.county IS NOT DISTINCT FROM fk.county
-        AND cb.utm_campaign IS NOT DISTINCT FROM fk.utm_campaign
-        AND cb.utm_medium IS NOT DISTINCT FROM fk.utm_medium
-        AND cb.utm_source IS NOT DISTINCT FROM fk.utm_source
 CROSS JOIN totals t
+WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 GROUP BY cb.benefit_name
 HAVING count(DISTINCT cb.screen_id) > 0
 ORDER BY count(DISTINCT cb.screen_id) DESC, max(cb.benefit_display_name) ASC

--- a/dashboards/sql/immediate_needs.sql
+++ b/dashboards/sql/immediate_needs.sql
@@ -1,17 +1,6 @@
 WITH totals AS (
     SELECT count(*) AS total_count FROM analytics.mart_screener_data
     WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
-),
-
-filter_keys AS (
-    SELECT DISTINCT
-        partner,
-        county,
-        utm_campaign,
-        utm_medium,
-        utm_source
-    FROM analytics.mart_screener_data
-    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 )
 
 SELECT
@@ -19,13 +8,7 @@ SELECT
     sum(n.count) AS "# of Screeners",
     sum(n.count)::FLOAT / nullif(max(t.total_count), 0) AS "% of Screeners"
 FROM analytics.mart_immediate_needs n
-INNER JOIN filter_keys fk
-    ON
-        n.partner IS NOT DISTINCT FROM fk.partner
-        AND n.county IS NOT DISTINCT FROM fk.county
-        AND n.utm_campaign IS NOT DISTINCT FROM fk.utm_campaign
-        AND n.utm_medium IS NOT DISTINCT FROM fk.utm_medium
-        AND n.utm_source IS NOT DISTINCT FROM fk.utm_source
 CROSS JOIN totals t
+WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 GROUP BY n.benefit
 ORDER BY sum(n.count) DESC, n.benefit ASC

--- a/dashboards/sql/qualified_benefits.sql
+++ b/dashboards/sql/qualified_benefits.sql
@@ -2,17 +2,6 @@ WITH totals AS (
     SELECT count(*) AS total_count
     FROM analytics.mart_screener_data
     WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
-),
-
-filter_keys AS (
-    SELECT DISTINCT
-        partner,
-        county,
-        utm_campaign,
-        utm_medium,
-        utm_source
-    FROM analytics.mart_screener_data
-    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 )
 
 SELECT
@@ -20,13 +9,7 @@ SELECT
     sum(qb.count) AS "# of Screeners",
     sum(qb.count)::FLOAT / nullif(max(t.total_count), 0) AS "% of Screeners"
 FROM analytics.mart_qualified_benefits qb
-INNER JOIN filter_keys fk
-    ON
-        qb.partner IS NOT DISTINCT FROM fk.partner
-        AND qb.county IS NOT DISTINCT FROM fk.county
-        AND qb.utm_campaign IS NOT DISTINCT FROM fk.utm_campaign
-        AND qb.utm_medium IS NOT DISTINCT FROM fk.utm_medium
-        AND qb.utm_source IS NOT DISTINCT FROM fk.utm_source
 CROSS JOIN totals t
+WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 GROUP BY qb.benefit
 ORDER BY sum(qb.count) DESC, qb.benefit ASC


### PR DESCRIPTION
## Problem

Following the Current Benefits card source swap in #95 (MFB-867), the **Current Benefits** dashboard card at https://dashboards.myfriendben.org/ began taking *minutes* to load. `EXPLAIN ANALYZE` on the card query ran for **>3.5 minutes without completing**.

## Root cause

All three SQL cards (`current_benefits`, `qualified_benefits`, `immediate_needs`) use a `filter_keys` CTE that joins the fact table back to a `SELECT DISTINCT (partner, county, utm_*)` of `mart_screener_data` via **`IS NOT DISTINCT FROM` on five columns**.

Null-safe equality can't be hashed or indexed, so the planner is forced into a `Nested Loop` with a `Join Filter`:

'''
GroupAggregate (cost=10555.21..4996851.61 rows=1)
  -> Nested Loop (cost=...4996851.60 rows=1)
       Join Filter: (NOT (cb.partner IS DISTINCT FROM msd.partner) AND ... x5)
       -> Parallel Seq Scan on mart_current_benefits cb (rows=37331)
       -> Materialize -> HashAggregate (rows=13077 distinct combos)
'''

For `mart_current_benefits` (~63k granular rows × 2,754 distinct filter combos) that's **~175M pair comparisons**, each running five null-safe string compares. The planner's `rows=1` estimate is wildly wrong (it can't estimate null-safe selectivity), which is why it picks this catastrophic plan and even fires up JIT.

The join was **pure dead weight** — it filtered nothing:
- All three marts derive `partner/county/utm_*` from `int_complete_screener_data`, the same source `mart_screener_data` is built from.
- So every `(partner, county, utm_*)` combo in a fact table is guaranteed to exist in `mart_screener_data` → the `INNER JOIN filter_keys` never dropped a row.
- It existed only as a binding surface for Metabase's '[[AND {{...}}]]' optional-filter placeholders.

## Fix

Drop the `filter_keys` CTE and bind the **same** filter placeholders directly to the fact table in a `WHERE` clause. Results are identical; the nested loop disappears (one seq scan + group-by).

## Scope

- **`current_benefits`** — the actual regression. Granular source → was genuinely slow.
- **`qualified_benefits`** / **`immediate_needs`** — same anti-pattern, but pre-aggregated sources made them cheap *today*. Fixed proactively to remove the latent footgun (they'd blow up identically if those marts ever went granular).

## Testing

- [x] Verified via dbt lineage that all three marts' filter columns descend from `int_complete_screener_data` (same source as `mart_screener_data`), so the dropped INNER JOIN was a no-op filter — counts are unchanged.
- [ ] **Reviewer:** confirm in Metabase that each card renders quickly and the numbers match the current production cards (same totals, same % values) for a couple of filter selections (e.g. one partner, a date range).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Relationship to MFB-998 / PR #92 (closed)

@cdadams1888's [PR #92 (MFB-998)](https://github.com/MyFriendBen/data-queries/pull/92) — *closed, not merged* — targeted the **same `filter_keys` anti-pattern** on these same cards. Its motivation was a correctness bug: **Texas urgent-needs table didn't load because many TX screeners have `county = NULL`**, which interacted badly with the `filter_keys` INNER JOIN + Metabase's optional `[[AND {{county}}]]` expansion. Its fix replaced the join with an `EXISTS` semi-join that kept `IS NOT DISTINCT FROM` for NULL-safety.

That PR predated #95 (it still queried `mart_previous_benefits` with `SUM(count)`, before MFB-867 swapped `current_benefits` to the granular `mart_current_benefits`), so it could not be merged as-is.

**This PR supersedes it and resolves the same NULL-county concern more simply:**

- The old INNER JOIN was a **no-op filter** — all three fact marts derive `partner/county/utm_*` from `int_complete_screener_data`, the same source as `mart_screener_data`, so every slice (NULL county included) is guaranteed present. Dropping the join changes no results.
- With no semi-join, a NULL-county row is simply **kept** (no `IS NOT DISTINCT FROM` matching to misbehave) — which is exactly the outcome MFB-998 wanted.
- Numerator and denominator stay consistent: the identical `[[AND {{county}}]]` placeholder binds to both the fact-table `WHERE` and the `totals` CTE, so a county filter drops NULL-county rows from both together (correct), and no filter keeps them in both (correct).

**Reviewer:** please specifically re-test the original MFB-998 scenario — open the TX urgent-needs (immediate_needs) card with **no county filter** and confirm it loads with data.


## Relationship to MFB-975 / PR #94 (merged) — RLS index scans

[PR #94 (MFB-975)](https://github.com/MyFriendBen/data-queries/pull/94), merged 2026-05-21, replaced the regex-on-`current_user` RLS with a session-GUC (`app.white_label_id`) + `STABLE` function so the RLS predicate becomes `white_label_id = <constant>` and **Postgres can use the `white_label_id` index instead of seq-scanning** each mart.

That fix and this one are **complementary — they fix two different costs on the same queries**:
- **#94** fixes the *RLS-layer* seq scan (now an index scan, per tenant, in Metabase).
- **This PR** fixes the *`filter_keys` cross-join* — a `Nested Loop` + `Join Filter` over five `IS NOT DISTINCT FROM` columns that #94's index scan does not touch.

**Caveat on the measured timing:** the `EXPLAIN ANALYZE` that ran >3.5 min was executed on an admin/dbt connection that does **not** set the `app.white_label_id` GUC, so RLS returned all rows and the plan showed a full `Parallel Seq Scan` (not the indexed per-tenant scan Metabase gets via JDBC options). The headline cost driver — the `filter_keys` nested loop — is real and independent of RLS, but in production each tenant's RLS first narrows the scan (indexed, thanks to #94), then this PR removes the join that was multiplying that narrowed set. Net: both fixes are needed; this one removes the cross-product, #94 keeps the scan indexed.


## Verification (2026-06-01)

Confirmed against **prod** with a real tenant's RLS set (`SET app.white_label_id = <tenant>`):
- **Original** card query (with `filter_keys` join): `EXPLAIN ANALYZE` ran >3.5 min without completing.
- **Rewritten** query (this PR, join removed): returns in well under a second.

Fix confirmed. Ready to merge → Terraform apply → Metabase cards refresh.
