### PR TITLE
Hotfix: revert qualified_benefits + immediate_needs cards (MFB-867)

### DIFF
--- a/dashboards/sql/immediate_needs.sql
+++ b/dashboards/sql/immediate_needs.sql
@@ -1,6 +1,17 @@
 WITH totals AS (
     SELECT count(*) AS total_count FROM analytics.mart_screener_data
     WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
+),
+
+filter_keys AS (
+    SELECT DISTINCT
+        partner,
+        county,
+        utm_campaign,
+        utm_medium,
+        utm_source
+    FROM analytics.mart_screener_data
+    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 )
 
 SELECT
@@ -8,7 +19,13 @@ SELECT
     sum(n.count) AS "# of Screeners",
     sum(n.count)::FLOAT / nullif(max(t.total_count), 0) AS "% of Screeners"
 FROM analytics.mart_immediate_needs n
+INNER JOIN filter_keys fk
+    ON
+        n.partner IS NOT DISTINCT FROM fk.partner
+        AND n.county IS NOT DISTINCT FROM fk.county
+        AND n.utm_campaign IS NOT DISTINCT FROM fk.utm_campaign
+        AND n.utm_medium IS NOT DISTINCT FROM fk.utm_medium
+        AND n.utm_source IS NOT DISTINCT FROM fk.utm_source
 CROSS JOIN totals t
-WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 GROUP BY n.benefit
 ORDER BY sum(n.count) DESC, n.benefit ASC

--- a/dashboards/sql/qualified_benefits.sql
+++ b/dashboards/sql/qualified_benefits.sql
@@ -2,6 +2,17 @@ WITH totals AS (
     SELECT count(*) AS total_count
     FROM analytics.mart_screener_data
     WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
+),
+
+filter_keys AS (
+    SELECT DISTINCT
+        partner,
+        county,
+        utm_campaign,
+        utm_medium,
+        utm_source
+    FROM analytics.mart_screener_data
+    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 )
 
 SELECT
@@ -9,7 +20,13 @@ SELECT
     sum(qb.count) AS "# of Screeners",
     sum(qb.count)::FLOAT / nullif(max(t.total_count), 0) AS "% of Screeners"
 FROM analytics.mart_qualified_benefits qb
+INNER JOIN filter_keys fk
+    ON
+        qb.partner IS NOT DISTINCT FROM fk.partner
+        AND qb.county IS NOT DISTINCT FROM fk.county
+        AND qb.utm_campaign IS NOT DISTINCT FROM fk.utm_campaign
+        AND qb.utm_medium IS NOT DISTINCT FROM fk.utm_medium
+        AND qb.utm_source IS NOT DISTINCT FROM fk.utm_source
 CROSS JOIN totals t
-WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 GROUP BY qb.benefit
 ORDER BY sum(qb.count) DESC, qb.benefit ASC


### PR DESCRIPTION
## Problem (prod outage)

PR #96 broke the **Qualified Benefits** and **Immediate Needs** cards in prod — "There was a problem displaying this chart" whenever the **Date Range** filter is set. Current Benefits is fine.

## Root cause

'{{submission_date}}' is a Metabase **field filter** ('target = ["dimension", ["template-tag", "submission_date"]]', wired from the 'date_range' dashboard parameter). A field filter binds to a **physical column on the card's FROM table** and expands to '<table>.submission_date BETWEEN ...'.

PR #96 moved the filters from the 'filter_keys' CTE (which selects 'FROM mart_screener_data') onto the aggregated benefit marts. But 'mart_qualified_benefits' and 'mart_immediate_needs' are **pre-aggregated and have no 'submission_date' column** → the expanded predicate referenced a nonexistent column → error.

It only triggered when the date filter had a value (empty filter collapses '[[...]]' to nothing) — which is why the query editor with empty filters ran fine (56ms).

## Fix

Revert these two cards to the original 'filter_keys' SQL (selects 'FROM mart_screener_data', so field filters bind correctly). These cards were **never the slow ones** — they're pre-aggregated, so 'filter_keys' was always cheap. No perf cost.

**'current_benefits' keeps the #96 fix** — it's the only genuinely slow card (granular '~63k' rows) and it *does* carry 'submission_date', so its direct-WHERE binding resolves correctly (verified in the Metabase editor).

## Deploy

Merge → auto Terraform apply → Metabase cards refresh. No dbt run / no scaling needed (card-SQL only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dashboard filtering to ensure filters for submission date, partner, county, and campaign parameters are applied accurately and consistently across all metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->