### PR TITLE
Fix current_benefits card: filter via mart_screener_data CTE + screen_id join (MFB-867)

### DIFF
--- a/dashboards/sql/current_benefits.sql
+++ b/dashboards/sql/current_benefits.sql
@@ -1,6 +1,12 @@
 WITH totals AS (
     SELECT count(*) AS total_count FROM analytics.mart_screener_data
     WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
+),
+
+filtered_screens AS (
+    SELECT id
+    FROM analytics.mart_screener_data
+    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 )
 
 SELECT
@@ -8,8 +14,8 @@ SELECT
     count(DISTINCT cb.screen_id) AS "# of Screeners",
     count(DISTINCT cb.screen_id)::FLOAT / nullif(max(t.total_count), 0) AS "% of Screeners"
 FROM analytics.mart_current_benefits cb
+INNER JOIN filtered_screens fs ON cb.screen_id = fs.id
 CROSS JOIN totals t
-WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 GROUP BY cb.benefit_name
 HAVING count(DISTINCT cb.screen_id) > 0
 ORDER BY count(DISTINCT cb.screen_id) DESC, max(cb.benefit_display_name) ASC


### PR DESCRIPTION
## Problem

After #96, the Current Benefits card ("What percentage of users said they already had certain benefits?") errored in prod whenever a dashboard filter had a value:

'''
ERROR: missing FROM-clause entry for table "mart_screener_data"
'''

(The two aggregated cards were separately reverted in #97; this completes the fix.)

## Root cause

The Metabase field filters ('{{submission_date}}', '{{partner}}', '{{county}}', '{{utm_*}}') are mapped to **'mart_screener_data' columns** and expand to **fully-qualified** references like 'mart_screener_data.submission_date = ...'. They can only appear in a query block whose FROM clause contains 'mart_screener_data'.

#96 moved those placeholders into the outer 'WHERE' against 'cb' ('mart_current_benefits') — which has no 'mart_screener_data' in its FROM → error. It only surfaced when a filter had a value (empty filters collapse '[[...]]' to nothing), which is why the query editor with empty filters ran fine (56ms) and hid the bug.

## Fix

Keep all filter placeholders inside CTEs over 'mart_screener_data':
- 'totals' — the denominator (count of filtered screeners)
- 'filtered_screens' — the set of screen ids matching the filters

Then 'INNER JOIN mart_current_benefits cb ON cb.screen_id = fs.id'.

This:
- ✅ binds field filters to 'mart_screener_data' (no missing-FROM error)
- ✅ uses an **indexed '=' equi-join on 'screen_id'** — NOT the 5-column 'IS NOT DISTINCT FROM' null-safe cross-join that caused the original >3.5 min hang
- ✅ preserves the '(screen_id, benefit_name)' grain

Same proven pattern as 'household_head_ages' / 'household_member_ages'.

## Verification

Tested against **prod with the date filter applied** (manually expanded SQL, 'SET app.white_label_id') — returns rows quickly. This is the filtered scenario that #96 missed by only testing with empty filters.

## Deploy

Merge → auto Terraform apply → Metabase card refresh. Card-SQL only; no dbt run / no scaling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)