### PR TITLE
Fix qualified_benefits + immediate_needs perf: COALESCE equi-join (MFB-867)

### DIFF
--- a/dashboards/sql/immediate_needs.sql
+++ b/dashboards/sql/immediate_needs.sql
@@ -5,11 +5,11 @@ WITH totals AS (
 
 filter_keys AS (
     SELECT DISTINCT
-        partner,
-        county,
-        utm_campaign,
-        utm_medium,
-        utm_source
+        coalesce(partner, '__NULL__') AS partner,
+        coalesce(county, '__NULL__') AS county,
+        coalesce(utm_campaign, '__NULL__') AS utm_campaign,
+        coalesce(utm_medium, '__NULL__') AS utm_medium,
+        coalesce(utm_source, '__NULL__') AS utm_source
     FROM analytics.mart_screener_data
     WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 )
@@ -21,11 +21,11 @@ SELECT
 FROM analytics.mart_immediate_needs n
 INNER JOIN filter_keys fk
     ON
-        n.partner IS NOT DISTINCT FROM fk.partner
-        AND n.county IS NOT DISTINCT FROM fk.county
-        AND n.utm_campaign IS NOT DISTINCT FROM fk.utm_campaign
-        AND n.utm_medium IS NOT DISTINCT FROM fk.utm_medium
-        AND n.utm_source IS NOT DISTINCT FROM fk.utm_source
+        coalesce(n.partner, '__NULL__') = fk.partner
+        AND coalesce(n.county, '__NULL__') = fk.county
+        AND coalesce(n.utm_campaign, '__NULL__') = fk.utm_campaign
+        AND coalesce(n.utm_medium, '__NULL__') = fk.utm_medium
+        AND coalesce(n.utm_source, '__NULL__') = fk.utm_source
 CROSS JOIN totals t
 GROUP BY n.benefit
 ORDER BY sum(n.count) DESC, n.benefit ASC

--- a/dashboards/sql/qualified_benefits.sql
+++ b/dashboards/sql/qualified_benefits.sql
@@ -6,11 +6,11 @@ WITH totals AS (
 
 filter_keys AS (
     SELECT DISTINCT
-        partner,
-        county,
-        utm_campaign,
-        utm_medium,
-        utm_source
+        coalesce(partner, '__NULL__') AS partner,
+        coalesce(county, '__NULL__') AS county,
+        coalesce(utm_campaign, '__NULL__') AS utm_campaign,
+        coalesce(utm_medium, '__NULL__') AS utm_medium,
+        coalesce(utm_source, '__NULL__') AS utm_source
     FROM analytics.mart_screener_data
     WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 )
@@ -22,11 +22,11 @@ SELECT
 FROM analytics.mart_qualified_benefits qb
 INNER JOIN filter_keys fk
     ON
-        qb.partner IS NOT DISTINCT FROM fk.partner
-        AND qb.county IS NOT DISTINCT FROM fk.county
-        AND qb.utm_campaign IS NOT DISTINCT FROM fk.utm_campaign
-        AND qb.utm_medium IS NOT DISTINCT FROM fk.utm_medium
-        AND qb.utm_source IS NOT DISTINCT FROM fk.utm_source
+        coalesce(qb.partner, '__NULL__') = fk.partner
+        AND coalesce(qb.county, '__NULL__') = fk.county
+        AND coalesce(qb.utm_campaign, '__NULL__') = fk.utm_campaign
+        AND coalesce(qb.utm_medium, '__NULL__') = fk.utm_medium
+        AND coalesce(qb.utm_source, '__NULL__') = fk.utm_source
 CROSS JOIN totals t
 GROUP BY qb.benefit
 ORDER BY sum(qb.count) DESC, qb.benefit ASC


### PR DESCRIPTION
## Problem

These two cards timed out in prod ("There was a problem displaying this chart") with the Date Range filter applied.

The 'filter_keys' CTE joined the aggregated benefit marts to a 'DISTINCT' of 'mart_screener_data' via 5-column 'IS NOT DISTINCT FROM'. Null-safe equality can't be hashed → nested loop: **~5.8s** raw, over Metabase's chart timeout once RLS (per-row 'white_label_id' check) is added.

## Why not the current_benefits fix

'current_benefits' was fixed by joining on indexed 'screen_id'. These marts are **pre-aggregated and have no 'screen_id'**, so that join isn't available.

## Fix

COALESCE the nullable join columns ('partner/county/utm_*') to a ''__NULL__'' sentinel on both sides → the join becomes plain '=' → **hashable**, so Postgres uses a hash join instead of a nested loop. Semantically identical to 'IS NOT DISTINCT FROM' (NULL matches NULL via the shared sentinel; no real value collides with ''__NULL__'').

Filters stay inside CTEs over 'mart_screener_data', so the Metabase field filters bind correctly.

## Verification

Tested against **prod with the date filter applied** (expanded SQL): both queries return **well under 1s**, down from 5.8s.

## Deploy

Merge → auto Terraform apply → Metabase refresh. Card-SQL only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized null value handling in dashboard filter logic for consistent behavior across partner, county, and campaign tracking dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->