### PR TITLE
Fix RLS function per-row evaluation: remove SET clause so it inlines (MFB-867)

### DIFF
--- a/dbt/macros/mfb_current_white_label_id_function.sql
+++ b/dbt/macros/mfb_current_white_label_id_function.sql
@@ -23,14 +23,23 @@
     {{ return('') }}
   {% endif %}
 
+  -- NOTE (MFB-867 perf): no `SET search_path` clause here on purpose. A SQL
+  -- function with a SET clause CANNOT be inlined by the planner, so it is
+  -- executed as an opaque function call — and under RLS that means a per-row
+  -- call (one current_setting() lookup per scanned row), which made the
+  -- qualified_benefits / immediate_needs dashboard cards time out. Without the
+  -- SET clause, this STABLE function inlines and folds to a single constant
+  -- per query, so the RLS predicate becomes `white_label_id = <const>` and
+  -- uses the btree index once. Search-path safety is preserved by fully
+  -- schema-qualifying every built-in (pg_catalog.*), so behavior does not
+  -- depend on the caller's search_path.
   CREATE OR REPLACE FUNCTION {{ target.schema }}.mfb_current_white_label_id()
   RETURNS integer
   LANGUAGE sql
   STABLE
   PARALLEL SAFE
-  SET search_path = ''
   AS $fn$
-    SELECT (NULLIF(TRIM(BOTH FROM current_setting('app.white_label_id', true)), ''))::integer
+    SELECT NULLIF(pg_catalog.btrim(pg_catalog.current_setting('app.white_label_id', true)), '')::integer
   $fn$;
 
   GRANT EXECUTE ON FUNCTION {{ target.schema }}.mfb_current_white_label_id() TO PUBLIC;


### PR DESCRIPTION
## Root cause (the real one)

The 'qualified_benefits' / 'immediate_needs' dashboard cards timed out in prod. After ruling out the join (fixed in #99) and field-filter binding (#98), the cause is the **RLS function being evaluated per row**.

'mfb_current_white_label_id()' had 'SET search_path = '''. **A SQL function with a SET clause cannot be inlined by the Postgres planner** — it runs as an opaque function call. The RLS policy injects it as 'white_label_id = mfb_current_white_label_id()', so it became a 'current_setting()' lookup on **every scanned row**.

The planner costs a STABLE function as ~free, so EXPLAIN showed a cheap plan (~11.8k) while execution **timed out (>10s)**. Proof: the identical query with a literal 'white_label_id = 1' ran in **13ms**.

## Fix

Drop the 'SET' clause so the STABLE function **inlines** and folds to a single constant per query → RLS predicate becomes 'white_label_id = <const>' → btree index used once.

Search-path safety (the original reason for 'SET search_path=''') is preserved by fully schema-qualifying the built-ins: 'pg_catalog.btrim', 'pg_catalog.current_setting'. 'NULLIF' is SQL syntax (not hijackable); 'integer' resolves from 'pg_catalog' unconditionally. **Tenant isolation is not weakened.**

## Verification

Tested against prod with a temp copy of the function ('mfb_wl_id_test'):
- Index Cond now shows the **inlined** 'current_setting(...)' expression (foldable to constant)
- 'EXPLAIN ANALYZE' execution time: **70ms** (was: timeout)

## ⚠️ Deploy note — NOT the usual flow

This macro runs in dbt's **'on-run-start'** hook, so the function is only recreated when **dbt runs**. Terraform-apply (triggered on merge) does **NOT** run dbt. A dbt invocation is required to apply this in prod — see deploy steps in the PR thread.

Fixes the last of the MFB-867 dashboard perf regressions (#96→#97→#98→#99→this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)