### PR TITLE
Fix benefit-card timeouts: scalar subquery instead of CROSS JOIN totals (MFB-867)

### DIFF
--- a/dashboards/sql/current_benefits.sql
+++ b/dashboards/sql/current_benefits.sql
@@ -1,9 +1,4 @@
-WITH totals AS (
-    SELECT count(*) AS total_count FROM analytics.mart_screener_data
-    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
-),
-
-filtered_screens AS (
+WITH filtered_screens AS (
     SELECT id
     FROM analytics.mart_screener_data
     WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
@@ -12,10 +7,13 @@ filtered_screens AS (
 SELECT
     max(cb.benefit_display_name) AS "Benefit Name",
     count(DISTINCT cb.screen_id) AS "# of Screeners",
-    count(DISTINCT cb.screen_id)::FLOAT / nullif(max(t.total_count), 0) AS "% of Screeners"
+    count(DISTINCT cb.screen_id)::FLOAT / nullif((
+        SELECT count(*)
+        FROM analytics.mart_screener_data
+        WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
+    ), 0) AS "% of Screeners"
 FROM analytics.mart_current_benefits cb
 INNER JOIN filtered_screens fs ON cb.screen_id = fs.id
-CROSS JOIN totals t
 GROUP BY cb.benefit_name
 HAVING count(DISTINCT cb.screen_id) > 0
 ORDER BY count(DISTINCT cb.screen_id) DESC, max(cb.benefit_display_name) ASC

--- a/dashboards/sql/immediate_needs.sql
+++ b/dashboards/sql/immediate_needs.sql
@@ -1,9 +1,4 @@
-WITH totals AS (
-    SELECT count(*) AS total_count FROM analytics.mart_screener_data
-    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
-),
-
-filter_keys AS (
+WITH filter_keys AS (
     SELECT DISTINCT
         coalesce(partner, '__NULL__') AS partner,
         coalesce(county, '__NULL__') AS county,
@@ -17,7 +12,11 @@ filter_keys AS (
 SELECT
     n.benefit AS "Need Category",
     sum(n.count) AS "# of Screeners",
-    sum(n.count)::FLOAT / nullif(max(t.total_count), 0) AS "% of Screeners"
+    sum(n.count)::FLOAT / nullif((
+        SELECT count(*)
+        FROM analytics.mart_screener_data
+        WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
+    ), 0) AS "% of Screeners"
 FROM analytics.mart_immediate_needs n
 INNER JOIN filter_keys fk
     ON
@@ -26,6 +25,5 @@ INNER JOIN filter_keys fk
         AND coalesce(n.utm_campaign, '__NULL__') = fk.utm_campaign
         AND coalesce(n.utm_medium, '__NULL__') = fk.utm_medium
         AND coalesce(n.utm_source, '__NULL__') = fk.utm_source
-CROSS JOIN totals t
 GROUP BY n.benefit
 ORDER BY sum(n.count) DESC, n.benefit ASC

--- a/dashboards/sql/qualified_benefits.sql
+++ b/dashboards/sql/qualified_benefits.sql
@@ -1,10 +1,4 @@
-WITH totals AS (
-    SELECT count(*) AS total_count
-    FROM analytics.mart_screener_data
-    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
-),
-
-filter_keys AS (
+WITH filter_keys AS (
     SELECT DISTINCT
         coalesce(partner, '__NULL__') AS partner,
         coalesce(county, '__NULL__') AS county,
@@ -18,7 +12,11 @@ filter_keys AS (
 SELECT
     qb.benefit AS "Benefit Name",
     sum(qb.count) AS "# of Screeners",
-    sum(qb.count)::FLOAT / nullif(max(t.total_count), 0) AS "% of Screeners"
+    sum(qb.count)::FLOAT / nullif((
+        SELECT count(*)
+        FROM analytics.mart_screener_data
+        WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
+    ), 0) AS "% of Screeners"
 FROM analytics.mart_qualified_benefits qb
 INNER JOIN filter_keys fk
     ON
@@ -27,6 +25,5 @@ INNER JOIN filter_keys fk
         AND coalesce(qb.utm_campaign, '__NULL__') = fk.utm_campaign
         AND coalesce(qb.utm_medium, '__NULL__') = fk.utm_medium
         AND coalesce(qb.utm_source, '__NULL__') = fk.utm_source
-CROSS JOIN totals t
 GROUP BY qb.benefit
 ORDER BY sum(qb.count) DESC, qb.benefit ASC


### PR DESCRIPTION
## Problem

The 'qualified_benefits' and 'immediate_needs' dashboard cards timed out (minutes / never loaded) even after the COALESCE join fix (#99) and the RLS-function-inlining fix (#100).

## Root cause

The 'CROSS JOIN totals t' (where 'totals' counts filtered 'mart_screener_data') confused the planner's row estimation for the multi-column COALESCE join. It estimated the join at **rows=1** and chose a **Nested Loop** — which exploded over the **~19k actual** joined rows. 'EXPLAIN' showed a cheap plan; real execution timed out. (This is why every isolated test looked fine but the card died.)

## Fix

Drop 'totals' / 'CROSS JOIN totals t'; compute the denominator as an **inline scalar subquery** in the '% of Screeners' expression. Identical result, but the planner now picks a **Hash Join**.

## Verification

- Raw 'EXPLAIN ANALYZE' (real data, date filter): **96 ms**, **Hash Join** (was: timeout / Nested Loop).
- **Ran through the real Metabase RLS path** (editor, date filter applied): returns fast. This is the validation the earlier fixes never actually passed.

## Scope

Applied to all 3 benefit/needs cards. 'current_benefits' already worked (#98 indexed 'screen_id' join) but carried the same 'CROSS JOIN' pattern → same treatment to remove latent risk.

**Audited all other cards:** remaining 'CROSS JOIN totals' usages are single-table (no join) or join on an indexed single 'screener_id' key with a tiny aggregated cross join — not the at-risk shape. No change needed.

Card SQL only — no mart/model change, no dbt run. Deploys via Terraform on merge.

Concludes the MFB-867 dashboard perf saga (#96 → #97 → #98 → #99 → #100 → this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced dashboard query performance by optimizing calculation structures in benefit screening reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->