### PR TITLE
MFB-1041: Add Washington (WA) Metabase tenant dashboards

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -57,6 +57,7 @@ jobs:
             --arg nc_user "$NC_DB_USER" --arg nc_pass "$NC_DB_PASS" \
             --arg co_user "$CO_DB_USER" --arg co_pass "$CO_DB_PASS" \
             --arg tx_user "$TX_DB_USER" --arg tx_pass "$TX_DB_PASS" \
+            --arg wa_user "$WA_DB_USER" --arg wa_pass "$WA_DB_PASS" \
             --arg il_user "$IL_DB_USER" --arg il_pass "$IL_DB_PASS" \
             --arg ma_user "$MA_DB_USER" --arg ma_pass "$MA_DB_PASS" \
             --arg cesn_user "$CESN_DB_USER" --arg cesn_pass "$CESN_DB_PASS" \
@@ -66,6 +67,7 @@ jobs:
               + (if $nc_user != "" and $nc_pass != "" then {nc: {username: $nc_user, password: $nc_pass}} else {} end)
               + (if $co_user != "" and $co_pass != "" then {co: {username: $co_user, password: $co_pass}} else {} end)
               + (if $tx_user != "" and $tx_pass != "" then {tx: {username: $tx_user, password: $tx_pass}} else {} end)
+              + (if $wa_user != "" and $wa_pass != "" then {wa: {username: $wa_user, password: $wa_pass}} else {} end)
               + (if $il_user != "" and $il_pass != "" then {il: {username: $il_user, password: $il_pass}} else {} end)
               + (if $ma_user != "" and $ma_pass != "" then {ma: {username: $ma_user, password: $ma_pass}} else {} end)
               + (if $cesn_user != "" and $cesn_pass != "" then {cesn: {username: $cesn_user, password: $cesn_pass}} else {} end)
@@ -82,6 +84,8 @@ jobs:
           CO_DB_PASS: ${{ secrets.CO_DB_PASS }}
           TX_DB_USER: ${{ secrets.TX_DB_USER }}
           TX_DB_PASS: ${{ secrets.TX_DB_PASS }}
+          WA_DB_USER: ${{ secrets.WA_DB_USER }}
+          WA_DB_PASS: ${{ secrets.WA_DB_PASS }}
           IL_DB_USER: ${{ secrets.IL_DB_USER }}
           IL_DB_PASS: ${{ secrets.IL_DB_PASS }}
           MA_DB_USER: ${{ secrets.MA_DB_USER }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -56,6 +56,7 @@ jobs:
             --arg nc_user "$NC_DB_USER" --arg nc_pass "$NC_DB_PASS" \
             --arg co_user "$CO_DB_USER" --arg co_pass "$CO_DB_PASS" \
             --arg tx_user "$TX_DB_USER" --arg tx_pass "$TX_DB_PASS" \
+            --arg wa_user "$WA_DB_USER" --arg wa_pass "$WA_DB_PASS" \
             --arg il_user "$IL_DB_USER" --arg il_pass "$IL_DB_PASS" \
             --arg ma_user "$MA_DB_USER" --arg ma_pass "$MA_DB_PASS" \
             --arg cesn_user "$CESN_DB_USER" --arg cesn_pass "$CESN_DB_PASS" \
@@ -65,6 +66,7 @@ jobs:
               + (if $nc_user != "" and $nc_pass != "" then {nc: {username: $nc_user, password: $nc_pass}} else {} end)
               + (if $co_user != "" and $co_pass != "" then {co: {username: $co_user, password: $co_pass}} else {} end)
               + (if $tx_user != "" and $tx_pass != "" then {tx: {username: $tx_user, password: $tx_pass}} else {} end)
+              + (if $wa_user != "" and $wa_pass != "" then {wa: {username: $wa_user, password: $wa_pass}} else {} end)
               + (if $il_user != "" and $il_pass != "" then {il: {username: $il_user, password: $il_pass}} else {} end)
               + (if $ma_user != "" and $ma_pass != "" then {ma: {username: $ma_user, password: $ma_pass}} else {} end)
               + (if $cesn_user != "" and $cesn_pass != "" then {cesn: {username: $cesn_user, password: $cesn_pass}} else {} end)
@@ -81,6 +83,8 @@ jobs:
           CO_DB_PASS: ${{ secrets.CO_DB_PASS }}
           TX_DB_USER: ${{ secrets.TX_DB_USER }}
           TX_DB_PASS: ${{ secrets.TX_DB_PASS }}
+          WA_DB_USER: ${{ secrets.WA_DB_USER }}
+          WA_DB_PASS: ${{ secrets.WA_DB_PASS }}
           IL_DB_USER: ${{ secrets.IL_DB_USER }}
           IL_DB_PASS: ${{ secrets.IL_DB_PASS }}
           MA_DB_USER: ${{ secrets.MA_DB_USER }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ tfplan
 
 # dashboards scripts
 dashboards/scripts/generated/
+
+# macOS
+.DS_Store

--- a/dashboards/GITHUB_SECRETS.md
+++ b/dashboards/GITHUB_SECRETS.md
@@ -119,6 +119,7 @@ ALTER DEFAULT PRIVILEGES FOR USER <default_credential_user> IN SCHEMA analytics
 | `NC_DB_USER/PASS` | `wl_nc_5_ro` | NC tenant Metabase (white_label_id=5) |
 | `CO_DB_USER/PASS` | `wl_co_1_ro` | CO tenant Metabase (white_label_id=1) |
 | `TX_DB_USER/PASS` | `wl_tx_40_ro` | TX tenant Metabase (white_label_id=40) |
+| `WA_DB_USER/PASS` | `wl_wa_41_ro` | WA tenant Metabase (white_label_id=41) |
 | `IL_DB_USER/PASS` | `wl_il_39_ro` | IL tenant Metabase (white_label_id=39) |
 | `MA_DB_USER/PASS` | `wl_ma_38_ro` | MA tenant Metabase (white_label_id=38) |
 | `CESN_DB_USER/PASS` | `wl_cesn_4_ro` | CESN tenant Metabase (white_label_id=4) |
@@ -151,6 +152,8 @@ ALTER DEFAULT PRIVILEGES FOR USER <default_credential_user> IN SCHEMA analytics
 | `CO_DB_PASS` | CO tenant credential password | Same as above |
 | `TX_DB_USER` | TX tenant credential username | `heroku pg:credentials:url -a cobenefits-api --name wl_tx_40_ro` |
 | `TX_DB_PASS` | TX tenant credential password | Same as above |
+| `WA_DB_USER` | WA tenant credential username | `heroku pg:credentials:url -a cobenefits-api --name wl_wa_41_ro` |
+| `WA_DB_PASS` | WA tenant credential password | Same as above |
 | `IL_DB_USER` | IL tenant credential username | `heroku pg:credentials:url -a cobenefits-api --name wl_il_39_ro` |
 | `IL_DB_PASS` | IL tenant credential password | Same as above |
 | `MA_DB_USER` | MA tenant credential username | `heroku pg:credentials:url -a cobenefits-api --name wl_ma_38_ro` |

--- a/dashboards/config_template.tf
+++ b/dashboards/config_template.tf
@@ -81,6 +81,7 @@ locals {
     nc                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = true, has_utm_filters = true }
     co                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false }
     tx                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false }
+    wa                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false }
     il                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false }
     ma                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false }
     cesn              = { has_tax_credits = false, has_immediate_needs = false, has_assets = false, has_expenses = false, has_partners = false, has_summary_metrics = false, has_utm_filters = false }
@@ -104,6 +105,7 @@ locals {
     nc                = ["all_time", "households", "benefits_needs", "google_analytics"]
     co                = ["all_time", "households", "benefits_needs", "google_analytics"]
     tx                = ["all_time", "households", "benefits_needs", "google_analytics"]
+    wa                = ["all_time", "households", "benefits_needs", "google_analytics"]
     il                = ["all_time", "households", "benefits_needs", "google_analytics"]
     ma                = ["all_time", "households", "benefits_needs", "google_analytics"]
     cesn              = ["all_time", "households", "benefits_needs", "cesn_homeowners_vs_renters", "google_analytics"]

--- a/dashboards/google_analytics.tf
+++ b/dashboards/google_analytics.tf
@@ -22,6 +22,7 @@ locals {
     nc   = ["nc"]
     co   = ["co"]
     tx   = ["tx"]
+    wa   = ["wa"]
     il   = ["il"]
     ma   = ["ma"]
     cesn = ["cesn"]

--- a/dashboards/metabase.tf
+++ b/dashboards/metabase.tf
@@ -162,9 +162,14 @@ resource "metabase_collection" "tenant_collection_tx" {
   depends_on = [metabase_collection.tenant_collection_co]
 }
 
+resource "metabase_collection" "tenant_collection_wa" {
+  name       = "Washington"
+  depends_on = [metabase_collection.tenant_collection_tx]
+}
+
 resource "metabase_collection" "tenant_collection_il" {
   name       = "Illinois"
-  depends_on = [metabase_collection.tenant_collection_tx]
+  depends_on = [metabase_collection.tenant_collection_wa]
 }
 
 resource "metabase_collection" "tenant_collection_ma" {
@@ -188,6 +193,7 @@ locals {
     nc                = metabase_collection.tenant_collection_nc
     co                = metabase_collection.tenant_collection_co
     tx                = metabase_collection.tenant_collection_tx
+    wa                = metabase_collection.tenant_collection_wa
     il                = metabase_collection.tenant_collection_il
     ma                = metabase_collection.tenant_collection_ma
     cesn              = metabase_collection.tenant_collection_cesn

--- a/dashboards/terraform.tfvars.example
+++ b/dashboards/terraform.tfvars.example
@@ -28,6 +28,10 @@ tenant_db_credentials = {
     username = "wl_tx_40_ro"
     password = "your_password"
   }
+  wa = {
+    username = "wl_wa_41_ro"
+    password = "your_password"
+  }
   il = {
     username = "wl_il_39_ro"
     password = "your_password"
@@ -65,6 +69,11 @@ tenants = {
     name           = "tx"
     display_name   = "Texas"
     white_label_id = 40
+  }
+  wa = {
+    name           = "wa"
+    display_name   = "Washington"
+    white_label_id = 41
   }
   il = {
     name           = "il"

--- a/dashboards/variables.tf
+++ b/dashboards/variables.tf
@@ -59,6 +59,11 @@ variable "tenants" {
       display_name   = "Texas"
       white_label_id = 40
     }
+    wa = {
+      name           = "wa"
+      display_name   = "Washington"
+      white_label_id = 41
+    }
     il = {
       name           = "il"
       display_name   = "Illinois"


### PR DESCRIPTION
## Summary

Registers **Washington (WA)** as a Metabase tenant (`white_label_id=41`, role `wl_wa_41_ro`) so all shared dashboard cards and tabs replicate automatically via the existing per-tenant `for_each` resources.

WA uses the standard **full-state feature profile** (matching TX/IL/MA):
- `has_tax_credits`, `has_immediate_needs`, `has_assets`, `has_expenses`, `has_partners` = true
- `has_summary_metrics`, `has_utm_filters` = false
- Tabs: Overall Performance, Households, Benefits & Immediate Needs, Google Analytics

`white_label_id=41` was confirmed against the production DB (GRAY read replica): `screener_whitelabel` row `41 | wa | Washington`.

## Changes

| File | Change |
|------|--------|
| `dashboards/variables.tf` | Add `wa` tenant to `var.tenants` default |
| `dashboards/terraform.tfvars.example` | Add `wa` to `tenants` + `tenant_db_credentials` |
| `dashboards/config_template.tf` | Add `wa` to `tenant_features` and `tenant_tabs` |
| `dashboards/metabase.tf` | Add `tenant_collection_wa` (chained tx → wa → il) and `wa` in `tenant_collection_map` |
| `dashboards/google_analytics.tf` | Add `wa` GA `state_code` mapping |
| `dashboards/GITHUB_SECRETS.md` | Document `WA_DB_USER`/`WA_DB_PASS` (`wl_wa_41_ro`) |
| `.github/workflows/terraform-{plan,apply}.yml` | Wire `WA_DB_USER`/`WA_DB_PASS` into tenant creds JSON |
| `.gitignore` | Ignore `.DS_Store` |

Tenant collections are **not** `for_each` (Metabase has a race condition creating collections concurrently), so `tenant_collection_wa` is added explicitly and chained into the sequential dependency order. Everything else expands automatically from `var.tenants`.

## Validation

- `terraform validate` → **Success! The configuration is valid.**
- `terraform fmt -check -recursive` → clean
- `local.alltime_scorecard_count["wa"]` resolves to `6` (correct for a tax-credit tenant)

The dbt marts are white-label-agnostic (no hardcoded state allowlist), so WA data flows through automatically via RLS — no dbt changes needed.

## ⚠️ Deployment follow-up (not in code — required before/at apply)

1. Create the Heroku Postgres credential: `heroku pg:credentials:create -a cobenefits-api --name wl_wa_41_ro`
2. Grant it analytics + RLS access (see `GITHUB_SECRETS.md` "Granting permissions").
3. Add GitHub Actions secrets `WA_DB_USER` / `WA_DB_PASS` (production environment) from the credential URL. *(Workflow linter warnings about `secrets.WA_DB_USER` are expected until these exist.)*
4. `terraform apply` — the `get_field_ids.py` external data source re-runs and picks up WA's filter field IDs automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)