### PR TITLE
Fix dashboard filter semi-join leak in current/previous benefits cards

### DIFF
--- a/dashboards/sql/immediate_needs.sql
+++ b/dashboards/sql/immediate_needs.sql
@@ -1,29 +1,103 @@
-WITH filter_keys AS (
-    SELECT DISTINCT
-        coalesce(partner, '__NULL__') AS partner,
-        coalesce(county, '__NULL__') AS county,
-        coalesce(utm_campaign, '__NULL__') AS utm_campaign,
-        coalesce(utm_medium, '__NULL__') AS utm_medium,
-        coalesce(utm_source, '__NULL__') AS utm_source
+WITH filtered_screens AS (
+    SELECT
+        needs_baby_supplies,
+        needs_child_dev_help,
+        needs_food,
+        needs_funeral_help,
+        needs_housing_help,
+        needs_mental_health_help,
+        needs_family_planning_help,
+        needs_dental_care,
+        needs_job_resources,
+        needs_legal_services,
+        needs_college_savings,
+        needs_veteran_services
     FROM analytics.mart_screener_data
-    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
+    WHERE 1 = 1
+        [[AND {{submission_date}}]]
+        [[AND {{partner}}]]
+        [[AND {{county}}]]
+        [[AND {{utm_campaign}}]]
+        [[AND {{utm_medium}}]]
+        [[AND {{utm_source}}]]
+),
+
+need_counts AS (
+    SELECT
+'Baby Supplies'     AS benefit,
+count(*) FILTER (WHERE needs_baby_supplies)        AS n
+FROM filtered_screens
+UNION ALL
+    SELECT
+'Child Development' AS benefit,
+count(*) FILTER (WHERE needs_child_dev_help)       AS n
+FROM filtered_screens
+UNION ALL
+    SELECT
+'Food'              AS benefit,
+count(*) FILTER (WHERE needs_food)                  AS n
+FROM filtered_screens
+UNION ALL
+    SELECT
+'Funeral'           AS benefit,
+count(*) FILTER (WHERE needs_funeral_help)          AS n
+FROM filtered_screens
+UNION ALL
+    SELECT
+'Housing'           AS benefit,
+count(*) FILTER (WHERE needs_housing_help)          AS n
+FROM filtered_screens
+UNION ALL
+    SELECT
+'Mental Health'     AS benefit,
+count(*) FILTER (WHERE needs_mental_health_help)    AS n
+FROM filtered_screens
+UNION ALL
+    SELECT
+'Family Planning'   AS benefit,
+count(*) FILTER (WHERE needs_family_planning_help)  AS n
+FROM filtered_screens
+UNION ALL
+    SELECT
+'Dental Care'       AS benefit,
+count(*) FILTER (WHERE needs_dental_care)           AS n
+FROM filtered_screens
+UNION ALL
+    SELECT
+'Job Resources'     AS benefit,
+count(*) FILTER (WHERE needs_job_resources)         AS n
+FROM filtered_screens
+UNION ALL
+    SELECT
+'Legal Services'    AS benefit,
+count(*) FILTER (WHERE needs_legal_services)        AS n
+FROM filtered_screens
+UNION ALL
+    SELECT
+'College Savings'   AS benefit,
+count(*) FILTER (WHERE needs_college_savings)       AS n
+FROM filtered_screens
+UNION ALL
+    SELECT
+'Veteran Services'  AS benefit,
+count(*) FILTER (WHERE needs_veteran_services)      AS n
+FROM filtered_screens
 )
 
 SELECT
-    n.benefit AS "Need Category",
-    sum(n.count) AS "# of Screeners",
-    sum(n.count)::FLOAT / nullif((
+    nc.benefit AS "Need Category",
+    nc.n AS "# of Screeners",
+    nc.n::FLOAT / nullif((
         SELECT count(*)
         FROM analytics.mart_screener_data
-        WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
+        WHERE 1 = 1
+            [[AND {{submission_date}}]]
+            [[AND {{partner}}]]
+            [[AND {{county}}]]
+            [[AND {{utm_campaign}}]]
+            [[AND {{utm_medium}}]]
+            [[AND {{utm_source}}]]
     ), 0) AS "% of Screeners"
-FROM analytics.mart_immediate_needs n
-INNER JOIN filter_keys fk
-    ON
-        coalesce(n.partner, '__NULL__') = fk.partner
-        AND coalesce(n.county, '__NULL__') = fk.county
-        AND coalesce(n.utm_campaign, '__NULL__') = fk.utm_campaign
-        AND coalesce(n.utm_medium, '__NULL__') = fk.utm_medium
-        AND coalesce(n.utm_source, '__NULL__') = fk.utm_source
-GROUP BY n.benefit
-ORDER BY sum(n.count) DESC, n.benefit ASC
+FROM need_counts nc
+WHERE nc.n > 0
+ORDER BY nc.n DESC, nc.benefit ASC

--- a/dashboards/sql/qualified_benefits.sql
+++ b/dashboards/sql/qualified_benefits.sql
@@ -1,29 +1,19 @@
-WITH filter_keys AS (
-    SELECT DISTINCT
-        coalesce(partner, '__NULL__') AS partner,
-        coalesce(county, '__NULL__') AS county,
-        coalesce(utm_campaign, '__NULL__') AS utm_campaign,
-        coalesce(utm_medium, '__NULL__') AS utm_medium,
-        coalesce(utm_source, '__NULL__') AS utm_source
+WITH filtered_screens AS (
+    SELECT id
     FROM analytics.mart_screener_data
     WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
 )
 
 SELECT
-    qb.benefit AS "Benefit Name",
-    sum(qb.count) AS "# of Screeners",
-    sum(qb.count)::FLOAT / nullif((
+    max(qb.benefit_display_name) AS "Benefit Name",
+    count(DISTINCT qb.screen_id) AS "# of Screeners",
+    count(DISTINCT qb.screen_id)::FLOAT / nullif((
         SELECT count(*)
         FROM analytics.mart_screener_data
         WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
     ), 0) AS "% of Screeners"
 FROM analytics.mart_qualified_benefits qb
-INNER JOIN filter_keys fk
-    ON
-        coalesce(qb.partner, '__NULL__') = fk.partner
-        AND coalesce(qb.county, '__NULL__') = fk.county
-        AND coalesce(qb.utm_campaign, '__NULL__') = fk.utm_campaign
-        AND coalesce(qb.utm_medium, '__NULL__') = fk.utm_medium
-        AND coalesce(qb.utm_source, '__NULL__') = fk.utm_source
-GROUP BY qb.benefit
-ORDER BY sum(qb.count) DESC, qb.benefit ASC
+INNER JOIN filtered_screens fs ON qb.screen_id = fs.id
+GROUP BY qb.benefit_name
+HAVING count(DISTINCT qb.screen_id) > 0
+ORDER BY count(DISTINCT qb.screen_id) DESC, max(qb.benefit_display_name) ASC

--- a/dbt/models/postgres/marts/mart_qualified_benefits.sql
+++ b/dbt/models/postgres/marts/mart_qualified_benefits.sql
@@ -5,13 +5,20 @@
   )
 }}
 
+-- One row per screen x benefit (mirrors mart_current_benefits grain).
+-- The pre-aggregated form (COUNT + GROUP BY tuple) caused a semi-join leak in
+-- dashboard queries: tuple matches could pull in benefit counts from screens
+-- outside the selected date range.  Exposing screen_id lets the dashboard SQL
+-- filter with `WHERE screen_id IN (SELECT id FROM mart_screener_data WHERE ...)`
+-- instead, which correctly enforces the date boundary.
 SELECT
-    COALESCE(MAX(pn.text), pe.name_abbreviated) AS benefit,
-    pe.name_abbreviated,
-    COUNT(DISTINCT msd.id) AS count,
+    msd.id                                              AS screen_id,
+    COALESCE(pn.text, pe.name_abbreviated)              AS benefit_display_name,
+    pe.name_abbreviated                                 AS benefit_name,
     msd.white_label_id,
     msd.partner,
     msd.county,
+    msd.submission_date,
     msd.utm_campaign,
     msd.utm_medium,
     msd.utm_source
@@ -29,11 +36,3 @@ LEFT JOIN {{ source('django_apps', 'translations_translation_translation') }} AS
     ON
         pp.name_id = pn.master_id
         AND pn.language_code = 'en-us'
-GROUP BY
-    pe.name_abbreviated,
-    msd.white_label_id,
-    msd.partner,
-    msd.county,
-    msd.utm_campaign,
-    msd.utm_medium,
-    msd.utm_source

--- a/dbt/models/postgres/marts/mart_qualified_benefits.yml
+++ b/dbt/models/postgres/marts/mart_qualified_benefits.yml
@@ -2,8 +2,29 @@ version: 2
 
 models:
   - name: mart_qualified_benefits
-    description: "Materialized mart that unpivots benefit eligibility data into rows for easier dashboarding. Contains counts of people who qualified for each benefit category by white_label_id and partner. Dynamic: joins stg_program_eligibility directly, so new programs are included automatically without code changes."
+    description: >
+      One row per screen × benefit for screens where the screener qualified for that
+      benefit (annual_value > 0).  Grain mirrors mart_current_benefits.
+
+      Previously this mart was pre-aggregated (COUNT + GROUP BY tuple), which caused
+      a date-filter semi-join leak in dashboard queries.  It now exposes screen_id so
+      dashboard SQL can safely filter with
+        WHERE screen_id IN (SELECT id FROM mart_screener_data WHERE <date/partner filters>)
+      instead of a tuple semi-join.
+
+      Dynamic: joins stg_program_eligibility directly, so new programs are included
+      automatically without code changes.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - screen_id
+            - benefit_name
     columns:
+      - name: screen_id
+        description: "Foreign key to screener_screen (mart_screener_data.id)"
+        tests:
+          - not_null
+
       - name: white_label_id
         description: "White label organization ID used for row-level security"
         tests:
@@ -11,20 +32,34 @@ models:
 
       - name: partner
         description: "Referral partner associated with the screener"
+
+      - name: county
+        description: "County associated with the screener"
+
+      - name: submission_date
+        description: "Date the screener was submitted"
+
+      - name: utm_campaign
+        description: "UTM campaign parameter from the screener"
+
+      - name: utm_medium
+        description: "UTM medium parameter from the screener"
+
+      - name: utm_source
+        description: "UTM source parameter from the screener"
+
+      - name: benefit_display_name
+        description: >
+          English (en-us) display name for the benefit program, scoped to the white
+          label. Falls back to benefit_name if no English translation exists.
+          Under RLS (per-WL queries), all rows for a given benefit_name share the same
+          display name.
         tests:
           - not_null
 
-      - name: benefit
-        description: "English (en-us) display name for the benefit program, scoped to the white label. Falls back to name_abbreviated if no English translation exists."
-        tests:
-          - not_null
-
-      - name: name_abbreviated
-        description: "Language-agnostic program identifier (e.g. 'snap', 'wic'). Use this for grouping instead of benefit to avoid translation duplicates."
-        tests:
-          - not_null
-
-      - name: count
-        description: "Number of distinct screeners that qualified for this benefit in the given partner/county group"
+      - name: benefit_name
+        description: >
+          Language-agnostic program slug (e.g. 'snap', 'wic'). Use this for grouping
+          instead of benefit_display_name to avoid translation duplicates.
         tests:
           - not_null


### PR DESCRIPTION
## Context & Motivation

- Fixes #[MFB-1086](https://linear.app/myfriendben/issue/MFB-1086/fix-dashboard-filter-semi-join-leak-in-currentprevious-benefits-cards)

The `qualified_benefits` and `immediate_needs` dashboard cards used a tuple semi-join on `(partner, county, utm_campaign, utm_medium, utm_source)` to filter benefit rows. This did not actually enforce the date filter — a benefit row from a screen **outside** the selected date range would be counted as long as its 5-tuple matched any in-range screen's 5-tuple. This caused over-counting on the "# of Screeners" and "% of Screeners" metrics, especially for popular partner/UTM combinations.

PR #101 already fixed `current_benefits.sql`; this PR applies the same fix to the remaining affected cards.

## Changes Made

- **`dashboards/sql/qualified_benefits.sql`** — Replaced the `filter_keys` tuple semi-join with a `filtered_screens` CTE that selects `id` from `mart_screener_data` with all filters applied, then joins `mart_qualified_benefits` on `screen_id` directly.
- **`dashboards/sql/immediate_needs.sql`** — Replaced the `filter_keys` tuple semi-join with a `filtered_screens` CTE that queries the `needs_*` boolean columns directly from the date-and-filter-bounded `mart_screener_data` rows.

## Testing

- dbt models to run:  `dbt run` (yes — `mart_qualified_benefits` model was modified)
- Terraform plan reviewed: no
- Local Metabase tested via docker-compose: yes
- Other manual testing steps:
  - Pick a narrow date range in Metabase and confirm per-benefit counts ≤ total screener count (previously could exceed due to the leak)
  - Compare qualified benefits / immediate needs counts against a direct query on `mart_screener_data` restricted to the same date window

## Deployment

- [x] Metabase container rebuild/redeploy needed: yes 
- [x] dbt production run needed (outside nightly cron): yes
- [x] Other post-deployment steps: Update the SQL in the affected Metabase question cards after merge

## Notes for Reviewers

