### PR TITLE
MFB-1019: Switch tax-credit aggregation from value_type to ProgramCategory.tax_category

### DIFF
--- a/data-queries/data_programs.sql
+++ b/data-queries/data_programs.sql
@@ -10,7 +10,6 @@ WITH translations_t AS (
     WHERE
         tt.label ILIKE 'program.%-name'
         OR tt.label ILIKE 'program.%-apply_button_link'
-        OR tt.label ILIKE 'program.%-value_type'
     ORDER BY tt.id
 ),
 
@@ -33,4 +32,3 @@ SELECT
     ttt.text
 FROM translations_t AS tt
 LEFT JOIN translations_tt AS ttt ON tt.id = ttt.master_id
-WHERE tt.label ILIKE 'program.%-value_type'

--- a/dbt/models/postgres/intermediate/int_complete_screener_data.sql
+++ b/dbt/models/postgres/intermediate/int_complete_screener_data.sql
@@ -283,16 +283,21 @@ benefit_aggregates AS (
     SELECT
         pe.eligibility_snapshot_id,
         SUM(
-            CASE WHEN pe.value_type = 'tax_credit' THEN pe.annual_value ELSE 0 END
+            CASE WHEN COALESCE(pc.tax_category, FALSE) = TRUE THEN pe.annual_value ELSE 0 END
         ) AS tax_credits_annual,
         SUM(
             CASE
-                WHEN pe.value_type IS DISTINCT FROM 'tax_credit'
+                WHEN COALESCE(pc.tax_category, FALSE) IS DISTINCT FROM TRUE
                     THEN pe.annual_value
                 ELSE 0
             END
         ) AS non_tax_credit_benefits_annual
     FROM {{ ref('stg_program_eligibility') }} AS pe
+    LEFT JOIN {{ source('django_apps', 'programs_program') }} AS pp
+        ON pe.name_abbreviated = pp.name_abbreviated
+        AND pe.white_label_id = pp.white_label_id
+    LEFT JOIN {{ source('django_apps', 'programs_programcategory') }} AS pc
+        ON pp.category_id = pc.id
     GROUP BY pe.eligibility_snapshot_id
 ),
 

--- a/dbt/models/postgres/intermediate/int_complete_screener_data.sql
+++ b/dbt/models/postgres/intermediate/int_complete_screener_data.sql
@@ -283,21 +283,12 @@ benefit_aggregates AS (
     SELECT
         pe.eligibility_snapshot_id,
         SUM(
-            CASE WHEN COALESCE(pc.tax_category, FALSE) = TRUE THEN pe.annual_value ELSE 0 END
+            CASE WHEN pe.tax_category THEN pe.annual_value ELSE 0 END
         ) AS tax_credits_annual,
         SUM(
-            CASE
-                WHEN COALESCE(pc.tax_category, FALSE) IS DISTINCT FROM TRUE
-                    THEN pe.annual_value
-                ELSE 0
-            END
+            CASE WHEN NOT pe.tax_category THEN pe.annual_value ELSE 0 END
         ) AS non_tax_credit_benefits_annual
     FROM {{ ref('stg_program_eligibility') }} AS pe
-    LEFT JOIN {{ source('django_apps', 'programs_program') }} AS pp
-        ON pe.name_abbreviated = pp.name_abbreviated
-        AND pe.white_label_id = pp.white_label_id
-    LEFT JOIN {{ source('django_apps', 'programs_programcategory') }} AS pc
-        ON pp.category_id = pc.id
     GROUP BY pe.eligibility_snapshot_id
 ),
 

--- a/dbt/models/postgres/sources.yml
+++ b/dbt/models/postgres/sources.yml
@@ -63,8 +63,6 @@ sources:
             description: "Full program name"
           - name: name_abbreviated
             description: "Abbreviated program name"
-          - name: value_type
-            description: "Type of benefit value"
           - name: estimated_value
             description: "Estimated dollar value of benefit"
           - name: estimated_delivery_time
@@ -104,10 +102,17 @@ sources:
             description: "Abbreviated program name (slug)"
           - name: name_id
             description: "Foreign key to translations_translation for the program display name"
-          - name: value_type_id
-            description: "Foreign key to translations_translation for the value type"
+          - name: category_id
+            description: "Foreign key to programs_programcategory"
           - name: white_label_id
             description: "White label organization ID for RLS"
+      - name: programs_programcategory
+        description: "Program category definitions from Django ProgramCategory model"
+        columns:
+          - name: id
+            description: "Primary key"
+          - name: tax_category
+            description: "True when all programs in this category are tax credits"
       - name: screener_current_benefits
         description: "Join table recording which programs a household currently receives at screen time"
         columns:

--- a/dbt/models/postgres/staging/stg_eligibility.sql
+++ b/dbt/models/postgres/staging/stg_eligibility.sql
@@ -15,7 +15,6 @@ SELECT
     pes.new,
     pes.name,
     pes.name_abbreviated,
-    pes.value_type,
     pes.estimated_value,
     pes.estimated_delivery_time,
     pes.estimated_application_time,

--- a/dbt/models/postgres/staging/stg_program_eligibility.sql
+++ b/dbt/models/postgres/staging/stg_program_eligibility.sql
@@ -1,18 +1,23 @@
 {{ config(
     materialized='view',
-    description='Program eligibility aggregated by snapshot — one row per eligibility_snapshot_id × name_abbreviated × value_type. pe.name (translated display name) is intentionally excluded: it varies by language and would fan-out rows per translation. white_label_id is sourced from screener_screen via the eligibility snapshot chain. No join to programs_program: the snapshot rows are already correctly scoped per-screen at eligibility run time, so cross-WL contamination is not possible, and joining to programs_program would silently drop historical rows whenever a program is renamed, deleted, or reassigned.'
+    description='Program eligibility aggregated by snapshot — one row per eligibility_snapshot_id × name_abbreviated × tax_category. pe.name (translated display name) is intentionally excluded: it varies by language and would fan-out rows per translation. white_label_id is sourced from screener_screen via the eligibility snapshot chain. programs_program is joined on name_abbreviated + white_label_id to resolve tax_category from ProgramCategory; LEFT JOIN ensures historical rows for deleted or reassigned programs are retained (tax_category coalesces to FALSE).'
 ) }}
 
 SELECT
     pe.eligibility_snapshot_id,
     pe.name_abbreviated,
-    pe.value_type,
+    COALESCE(pc.tax_category, FALSE) AS tax_category,
     scr.white_label_id,
-    sum(pe.estimated_value) AS annual_value
+    SUM(pe.estimated_value) AS annual_value
 FROM {{ source('django_apps', 'screener_programeligibilitysnapshot') }} AS pe
 INNER JOIN {{ source('django_apps', 'screener_eligibilitysnapshot') }} AS es
     ON pe.eligibility_snapshot_id = es.id
 INNER JOIN {{ source('django_apps', 'screener_screen') }} AS scr
     ON es.screen_id = scr.id
+LEFT JOIN {{ source('django_apps', 'programs_program') }} AS pp
+    ON pe.name_abbreviated = pp.name_abbreviated
+    AND scr.white_label_id = pp.white_label_id
+LEFT JOIN {{ source('django_apps', 'programs_programcategory') }} AS pc
+    ON pp.category_id = pc.id
 WHERE pe.eligible = TRUE
-GROUP BY pe.eligibility_snapshot_id, pe.name_abbreviated, pe.value_type, scr.white_label_id
+GROUP BY pe.eligibility_snapshot_id, pe.name_abbreviated, COALESCE(pc.tax_category, FALSE), scr.white_label_id


### PR DESCRIPTION

## Context & Motivation

Eliminates drift surface: new WLs previously had to set `value_type` on every tax-credit program; now a single `tax_category=True` checkbox on the category is sufficient.


- Fixes [MFB-1019](https://linear.app/myfriendben/issue/MFB-1019/retire-programvalue-type-switch-dbt-tax-credit-aggregation-to)
- Related PR: [BE PR](https://github.com/MyFriendBen/benefits-api/pull/1591), [FE PR](https://github.com/MyFriendBen/benefits-calculator/pull/2134)

## Changes Made

**dbt models**
- `int_complete_screener_data.sql` — rewrote `benefit_aggregates` CTE to join `stg_program_eligibility → programs_program → programs_programcategory` and split on `pc.tax_category` instead of `pe.value_type = 'tax_credit'`
- `stg_program_eligibility.sql` — replaced `pe.value_type` with `COALESCE(pc.tax_category, FALSE) AS tax_category` via LEFT JOIN to `programs_program` + `programs_programcategory`; updated `GROUP BY` and description accordingly
- `stg_eligibility.sql` — removed `pes.value_type` column

**sources.yml**
- Removed `value_type` column from `screener_programeligibilitysnapshot`
- Removed `value_type_id` from `programs_program`, added `category_id`
- Added `programs_programcategory` as a new source (columns: `id`, `tax_category`)

**data_programs.sql**
- Removed `program.%-value_type` translation lookup from `translations_t` CTE and final `WHERE` clause; view now returns `name` and `apply_button_link` translations only


## Testing

<!-- Steps needed to test this PR locally -->

1. dbt models to run: `dbt build --select stg_program_eligibility stg_eligibility int_complete_screener_data` verify rebuilds.
2. Query `analytics_internal.stg_program_eligibility` — confirm `tax_category` column exists, `value_type` is gone.
3. Open Metabase locally, go to any WL dashboard with tax-credit programs (e.g. CO) — confirm the "Median Annual Tax Credits" card renders without errors.
4. Confirm `analytics_internal.stg_eligibility` no longer has a `value_type` column.

## Deployment

<!--
Merging to main automatically applies Terraform changes to production.
Metabase container rebuilds and out-of-band dbt runs require manual steps — note them here.
-->

- [ ] Metabase container rebuild/redeploy needed: no
- [ ] dbt production run needed (outside nightly cron): yes 
run `dbt build --select stg_program_eligibility stg_eligibility int_complete_screener_data` after merge so Metabase reflects updated aggregations immediately
- [ ] Other post-deployment steps: None

## Notes for Reviewers

⚠️ **Do not merge until the data audit passes in prod.**
Run the following in the prod Django shell — must return **0 rows** before merging:
 ```python
 from programs.models import Program

 Program.objects.filter(value_type='tax_credit').exclude(
     category__tax_category=True
 ).values('white_label__code', 'name_abbreviated', 'category__external_name')
```
If any rows are returned, go to Django admin → Programs → Programs, search by `name_abbreviated`, and update the `category` field to the WL's tax-credit category. 
For exp: - `Programs → Programs → tx_aca` → set category to `Tax Credits`

Then re-run the query until it returns 0 rows before merging.

- Known limitations:
- Future considerations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated program benefit categorization framework to distinguish between tax credits and other benefit types.
  * Improved eligibility data processing for more accurate benefit aggregation in screener operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->