### PR TITLE
MFB-1202: MA Disability Data

### DIFF
--- a/dashboards/config_template.tf
+++ b/dashboards/config_template.tf
@@ -78,14 +78,14 @@ locals {
   # Per-tenant feature flags — controls which cards appear on shared dashboard tabs.
   # Add a new tenant here instead of scattering tenant-key conditionals across layout files.
   tenant_features = {
-    nc                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = true, has_utm_filters = true }
-    co                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false }
-    tx                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false }
-    wa                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false }
-    il                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false }
-    ma                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false }
-    cesn              = { has_tax_credits = false, has_immediate_needs = false, has_assets = false, has_expenses = false, has_partners = false, has_summary_metrics = false, has_utm_filters = false }
-    co_tax_calculator = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false }
+    nc                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = true, has_utm_filters = true, has_demographics_card = false }
+    co                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false, has_demographics_card = false }
+    tx                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false, has_demographics_card = false }
+    wa                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false, has_demographics_card = false }
+    il                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false, has_demographics_card = false }
+    ma                = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false, has_demographics_card = true }
+    cesn              = { has_tax_credits = false, has_immediate_needs = false, has_assets = false, has_expenses = false, has_partners = false, has_summary_metrics = false, has_utm_filters = false, has_demographics_card = false }
+    co_tax_calculator = { has_tax_credits = true, has_immediate_needs = true, has_assets = true, has_expenses = true, has_partners = true, has_summary_metrics = false, has_utm_filters = false, has_demographics_card = false }
   }
 
   # All available dashboard tabs with fixed IDs — per tenant so names can vary

--- a/dashboards/households.tf
+++ b/dashboards/households.tf
@@ -99,6 +99,45 @@ resource "metabase_card" "tenant_median_monthly_expenses" {
   }))
 }
 
+# --- Demographic percentage scorecards (MFB-1202) ---
+# Shown only on tenants with has_demographics_card = true. Denominator is
+# individual household members matching the active filters (partner = unique
+# link, county, date, UTM), joined to the filtered screener set.
+
+resource "metabase_card" "tenant_pct_young_adults" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_percentage_card_config, {
+    name          = "% Young Adults"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = templatefile("${path.module}/sql/pct_young_adults.sql", {})
+        "template-tags" = local.filter_template_tags[each.key]
+      }
+    }
+    visualization_settings = local.benefits_pct_visualization_settings
+  }))
+}
+
+resource "metabase_card" "tenant_pct_disabled" {
+  for_each = var.tenants
+  json = jsonencode(merge(local.tenant_percentage_card_config, {
+    name          = "% Disabled"
+    collection_id = tonumber(local.tenant_collection_map[each.key].id)
+    dataset_query = {
+      type     = "native"
+      database = tonumber(metabase_database.tenant_postgres[each.key].id)
+      native = {
+        query           = templatefile("${path.module}/sql/pct_disabled.sql", {})
+        "template-tags" = local.filter_template_tags[each.key]
+      }
+    }
+    visualization_settings = local.benefits_pct_visualization_settings
+  }))
+}
+
 # --- Age distribution bar charts ---
 
 resource "metabase_card" "tenant_head_of_household_ages" {
@@ -841,6 +880,77 @@ locals {
               { parameter_id = "utm_campaign_filter", card_id = tonumber(metabase_card.tenant_common_expenses[k].id), target = ["dimension", ["template-tag", "utm_campaign"]] },
               { parameter_id = "utm_medium_filter", card_id = tonumber(metabase_card.tenant_common_expenses[k].id), target = ["dimension", ["template-tag", "utm_medium"]] },
               { parameter_id = "utm_source_filter", card_id = tonumber(metabase_card.tenant_common_expenses[k].id), target = ["dimension", ["template-tag", "utm_source"]] }
+            ] : []
+          )
+          series                 = []
+          visualization_settings = {}
+        },
+      ] : [],
+      # Row 36: Demographic percentage scorecards (MFB-1202) — tenants with the flag only
+      local.tenant_features[k].has_demographics_card ? [
+        {
+          card_id          = tonumber(metabase_card.tenant_pct_young_adults[k].id)
+          dashboard_tab_id = 4
+          row              = 36
+          col              = 0
+          size_x           = 6
+          size_y           = 4
+          parameter_mappings = concat(
+            [
+              {
+                parameter_id = "date_range_filter"
+                card_id      = tonumber(metabase_card.tenant_pct_young_adults[k].id)
+                target       = ["dimension", ["template-tag", "submission_date"]]
+              },
+              {
+                parameter_id = "partner_filter"
+                card_id      = tonumber(metabase_card.tenant_pct_young_adults[k].id)
+                target       = ["dimension", ["template-tag", "partner"]]
+              },
+              {
+                parameter_id = "county_filter"
+                card_id      = tonumber(metabase_card.tenant_pct_young_adults[k].id)
+                target       = ["dimension", ["template-tag", "county"]]
+              }
+            ],
+            local.tenant_features[k].has_utm_filters ? [
+              { parameter_id = "utm_campaign_filter", card_id = tonumber(metabase_card.tenant_pct_young_adults[k].id), target = ["dimension", ["template-tag", "utm_campaign"]] },
+              { parameter_id = "utm_medium_filter", card_id = tonumber(metabase_card.tenant_pct_young_adults[k].id), target = ["dimension", ["template-tag", "utm_medium"]] },
+              { parameter_id = "utm_source_filter", card_id = tonumber(metabase_card.tenant_pct_young_adults[k].id), target = ["dimension", ["template-tag", "utm_source"]] }
+            ] : []
+          )
+          series                 = []
+          visualization_settings = {}
+        },
+        {
+          card_id          = tonumber(metabase_card.tenant_pct_disabled[k].id)
+          dashboard_tab_id = 4
+          row              = 36
+          col              = 6
+          size_x           = 6
+          size_y           = 4
+          parameter_mappings = concat(
+            [
+              {
+                parameter_id = "date_range_filter"
+                card_id      = tonumber(metabase_card.tenant_pct_disabled[k].id)
+                target       = ["dimension", ["template-tag", "submission_date"]]
+              },
+              {
+                parameter_id = "partner_filter"
+                card_id      = tonumber(metabase_card.tenant_pct_disabled[k].id)
+                target       = ["dimension", ["template-tag", "partner"]]
+              },
+              {
+                parameter_id = "county_filter"
+                card_id      = tonumber(metabase_card.tenant_pct_disabled[k].id)
+                target       = ["dimension", ["template-tag", "county"]]
+              }
+            ],
+            local.tenant_features[k].has_utm_filters ? [
+              { parameter_id = "utm_campaign_filter", card_id = tonumber(metabase_card.tenant_pct_disabled[k].id), target = ["dimension", ["template-tag", "utm_campaign"]] },
+              { parameter_id = "utm_medium_filter", card_id = tonumber(metabase_card.tenant_pct_disabled[k].id), target = ["dimension", ["template-tag", "utm_medium"]] },
+              { parameter_id = "utm_source_filter", card_id = tonumber(metabase_card.tenant_pct_disabled[k].id), target = ["dimension", ["template-tag", "utm_source"]] }
             ] : []
           )
           series                 = []

--- a/dashboards/sql/pct_disabled.sql
+++ b/dashboards/sql/pct_disabled.sql
@@ -1,9 +1,17 @@
 -- % of household members with a disability, among members who answered the
--- disability question. screener_householdmember.disabled is a nullable boolean;
--- NULL means the question was not recorded for that member (common for
--- children/spouses, and for tenants whose flow doesn't capture it). We exclude
--- NULLs so the rate reflects prevalence among respondents and isn't deflated by
--- unanswered rows — matching how the age card excludes null ages.
+-- disability questions. "Disabled" mirrors the screener's own definition
+-- (HouseholdMember.has_disability in benefits-api): a member counts as disabled
+-- if ANY of the three self-reported flags is true —
+--   disabled              (the explicit "Disabled" option)
+--   visually_impaired     (the "Blind or visually impaired" option)
+--   long_term_disability  (the "Any medical condition" option)
+-- These are all nullable booleans; NULL means the question was not recorded for
+-- that member (the three are not always captured together — e.g. the medical-
+-- condition option was added later, so older rows have it NULL). We include a
+-- member in the denominator if they answered AT LEAST ONE of the three, and
+-- treat NULL as "not that condition" in the numerator. Members with all three
+-- NULL (never asked) are excluded so the rate reflects prevalence among
+-- respondents, consistent with how the age card excludes null ages.
 WITH filter_keys AS (
     SELECT id
     FROM analytics.mart_screener_data
@@ -11,8 +19,14 @@ WITH filter_keys AS (
 )
 
 SELECT
-    count(*) FILTER (WHERE hm.disabled)::FLOAT
+    count(*) FILTER (
+        WHERE hm.disabled IS TRUE
+            OR hm.visually_impaired IS TRUE
+            OR hm.long_term_disability IS TRUE
+    )::FLOAT
     / nullif(count(*), 0) AS pct
 FROM analytics.mart_householdmembers hm
 INNER JOIN filter_keys fk ON hm.screener_id = fk.id
 WHERE hm.disabled IS NOT NULL
+    OR hm.visually_impaired IS NOT NULL
+    OR hm.long_term_disability IS NOT NULL

--- a/dashboards/sql/pct_disabled.sql
+++ b/dashboards/sql/pct_disabled.sql
@@ -1,3 +1,9 @@
+-- % of household members with a disability, among members who answered the
+-- disability question. screener_householdmember.disabled is a nullable boolean;
+-- NULL means the question was not recorded for that member (common for
+-- children/spouses, and for tenants whose flow doesn't capture it). We exclude
+-- NULLs so the rate reflects prevalence among respondents and isn't deflated by
+-- unanswered rows — matching how the age card excludes null ages.
 WITH filter_keys AS (
     SELECT id
     FROM analytics.mart_screener_data
@@ -9,3 +15,4 @@ SELECT
     / nullif(count(*), 0) AS pct
 FROM analytics.mart_householdmembers hm
 INNER JOIN filter_keys fk ON hm.screener_id = fk.id
+WHERE hm.disabled IS NOT NULL

--- a/dashboards/sql/pct_disabled.sql
+++ b/dashboards/sql/pct_disabled.sql
@@ -1,0 +1,11 @@
+WITH filter_keys AS (
+    SELECT id
+    FROM analytics.mart_screener_data
+    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
+)
+
+SELECT
+    count(*) FILTER (WHERE hm.disabled)::FLOAT
+    / nullif(count(*), 0) AS pct
+FROM analytics.mart_householdmembers hm
+INNER JOIN filter_keys fk ON hm.screener_id = fk.id

--- a/dashboards/sql/pct_young_adults.sql
+++ b/dashboards/sql/pct_young_adults.sql
@@ -1,0 +1,12 @@
+WITH filter_keys AS (
+    SELECT id
+    FROM analytics.mart_screener_data
+    WHERE 1 = 1 [[AND {{submission_date}}]] [[AND {{partner}}]] [[AND {{county}}]] [[AND {{utm_campaign}}]] [[AND {{utm_medium}}]] [[AND {{utm_source}}]]
+)
+
+SELECT
+    count(*) FILTER (WHERE hm.age BETWEEN 19 AND 24)::FLOAT
+    / nullif(count(*), 0) AS pct
+FROM analytics.mart_householdmembers hm
+INNER JOIN filter_keys fk ON hm.screener_id = fk.id
+WHERE hm.age IS NOT NULL


### PR DESCRIPTION
## Context & Motivation

<!-- Required: Why is this change needed? Link to issue, describe the problem, or explain the goal -->

A key Massachusetts partner/funder running a summer camp uses a unique referrer link. They want to know, of the households that screened through that link, what share are young adults and what share have a disability. This adds those two metrics to the MA dashboard, driven by the existing Partner filter (their unique link).

- Linear: [MFB-1202 — MA Disability Data](https://linear.app/myfriendben/issue/MFB-1202/ma-disability-data)
- Related PR: n/a

## Changes Made

<!-- Required: What specifically changed? Be concrete and specific -->

Two independent, decoupled scorecards on the MA Households tab (no shared denominator):

- **`% Young Adults`** (`dashboards/sql/pct_young_adults.sql`) — members aged 19–24 (matches existing age bins), among members with a non-null age. Age-based only; unrelated to the disability metric.
- **`% Disabled`** (`dashboards/sql/pct_disabled.sql`) — mirrors the screener's own `HouseholdMember.has_disability()` definition (benefits-api): a member counts as disabled if **any** of three self-reported flags is true:
  - `disabled` — the explicit "Disabled" option
  - `visually_impaired` — the "Blind or visually impaired" option
  - `long_term_disability` — the "Any medical condition" option
  Denominator = members who answered **at least one** of the three (`... IS NOT NULL OR ...`). See "Notes for Reviewers" for the NULL rationale.

Both compute over individual household members (`analytics.mart_householdmembers`) joined to the filtered screener set, honoring the dashboard filters (submission date, partner, county, UTM).

- **New cards** in `dashboards/households.tf` (`tenant_pct_young_adults`, `tenant_pct_disabled`) — percent-formatted scalar scorecards reusing `tenant_percentage_card_config` + `benefits_pct_visualization_settings`, defined per tenant via `for_each = var.tenants`.
- **New per-tenant feature flag** `has_demographics_card` in `dashboards/config_template.tf` — `true` for `ma`, `false` for all other tenants.
- **Layout** in `dashboards/households.tf` — the two scorecards are placed side-by-side on a new bottom row (row 36) of the Households tab, gated on `has_demographics_card`, with parameter mappings to the date/partner/county (+UTM when enabled) filters. Placed at the bottom to avoid renumbering existing rows.
- No dbt/mart changes: `disabled`, `visually_impaired`, `long_term_disability`, and `age` already exist in `mart_householdmembers`.

## Testing

<!-- Steps needed to test this PR locally -->

- Migrations to run: none
- Configuration updates needed: none (uses existing `var.tenants` / `tenant_features`)
- Environment variables/settings to add: none
- Manual testing steps:
  - `cd dashboards && terraform init && terraform fmt -check && terraform validate` — validated locally (config is valid; fmt clean).
  - **SQL logic verified against a local `analytics` DB** (no Docker/Metabase needed): confirmed the three disability columns and `age` are booleans/integer, and ran the exact card logic. For a dev tenant with populated data: `% Young Adults` ≈ 4.4%; `% Disabled` (any-of-three, answered-only) ≈ 18.6% — vs 10.0% when counting `disabled` alone, confirming the two added flags carry real signal. Local DB has no MA (`white_label_id = 38`) rows, so real MA figures can only be confirmed against prod.
  - For a full visual check, run a local Metabase (requires Docker; see `dashboards/README.md`), copy `local_override.tf.example` → `local_override.tf`, then `terraform plan`/`apply` and confirm two new cards + two Households-tab dashcards appear for `ma` only.
  - In Metabase, open the Massachusetts Dashboard → Households tab, apply the summer-camp Partner filter, and verify the "% Young Adults" and "% Disabled" scorecards recompute.

## Deployment

<!--
Steps needed AFTER merging to main (which automatically deploys to Staging)
-->

- Post-deployment scripts needed: none — merge to `main` triggers `terraform-apply.yml` against production.
- Production config updates: none
- Admin updates needed: none (MA viewers already have access to the MA collection/dashboard)
- Notify team/users of: the MA partner/funder that the % Young Adults and % Disabled cards are live on the MA dashboard.

## Notes for Reviewers

<!-- Optional: Anything specific you want reviewers to focus on or be aware of -->

- **`% Disabled` counts all three disability signals (per MFB-1202 clarification).** The requester confirmed that "Blind or visually impaired" and "Any medical condition" should count as disabled alongside the explicit "Disabled" option. The query therefore ORs `disabled`, `visually_impaired`, and `long_term_disability`, matching `HouseholdMember.has_disability()` in benefits-api. Counting `disabled` alone understates the rate (~10% → ~18.6% on a dev tenant).
- **`% Young Adults` is a fully separate, age-only metric** — decoupled from disability, its own denominator (members with a non-null age).
- **Column types / NULL handling.** All three disability fields are nullable `boolean`s sourced unchanged from `screener_householdmember`. `NULL` means the question was not recorded for that member (verified: it's a reachable state on submitted screens — `submission_date` is stamped by the eligibility GET independent of member fields, and the frontend writes `null` when a condition key is absent). The three are not always captured together (the medical-condition option was added later, so some rows have it NULL while the others are answered). We therefore: include a member in the denominator if they answered **at least one** of the three (`... IS NOT NULL`), treat NULL as "not that condition" in the numerator, and exclude members with all three NULL — so the rate reflects prevalence among respondents, consistent with how `% Young Adults` excludes null ages.
- **Metric definitions confirmed with the funder:** both metrics are "% of individual household members" (respondents); "young adult" = ages 19–24.
- Known limitations: MA-only by design (flag-gated); the underlying cards are created for every tenant but only placed on the MA dashboard. Could not test against real MA data locally (no `white_label_id = 38` rows in the local DB).
- Future considerations: if other tenants want the same metrics, just flip `has_demographics_card = true` for them. Separately, the frontend emitting `null` (rather than `false`) for unanswered disability conditions is a latent data-quality issue worth its own ticket in `benefits-calculator` (`updateScreen.ts` `?? null`), independent of this dashboard PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new Households dashboard metrics for the percentage of young adults and people with disabilities.
  * Metrics support existing date, partner, county, and optional UTM filters.
  * Demographics cards are now configurable per tenant and appear only where enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->